### PR TITLE
feat: Generator naming, identity, and derived generators (#2)

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -8,13 +8,13 @@ Line comments begin with `//` and run to end of line. Block comments are delimit
 
 ```flux
 // this is a line comment
-note [0 2 4]  // inline comment
+note lead [0 2 4]  // inline comment
 
 /*
   This is a
   multi-line comment
 */
-note [0 1 2 3]
+note lead [0 1 2 3]
 ```
 
 ## Generators
@@ -51,9 +51,9 @@ Specifically for `'wran`: weight for each element is 1 by default. The weight ca
 `_` marks an event slot as silence. It occupies the same time as any other element but no synth is spawned. The evaluator emits a `ScheduledEvent` with `type: 'rest'` so the scheduler knows the slot was intentionally silent (useful for `'mono` legato handling and visualisation).
 
 ```flux
-note [0 2 _ 4]    // rest on the 3rd slot — 4 elements, each gets 1/4 cycle
-note [_ 2 4]      // rest on the 1st slot
-[0 _ 2]'stut      // rest is repeated alongside notes
+note lead [0 2 _ 4]    // rest on the 3rd slot — 4 elements, each gets 1/4 cycle
+note lead [_ 2 4]      // rest on the 1st slot
+[0 _ 2]'stut           // rest is repeated alongside notes (inside a list, not a top-level statement)
 ```
 
 `_` cannot carry accidentals, `?` weights, or generator suffixes — it is purely syntactic and carries no pitch information.
@@ -126,24 +126,24 @@ A number of generators work by filtering events that come from upstream generato
 The `'stut(n)` modifier repeats every element n times. Default: n = 2. The bare form `'stut` is valid and equivalent to `'stut(2)`.
 
 ```flux
-note [0'stut]                              // 0 yielded 2 times
+note lead [0'stut]                              // 0 yielded 2 times
 
 // play each generated value two times instead of one
-note [0rand7 4rand6]'stut
+note lead [0rand7 4rand6]'stut
 
 // repeat each generated value 4 times
-note [0rand7 4rand6]'stut(4)
+note lead [0rand7 4rand6]'stut(4)
 
 // repeat each value 2-4 times, count drawn once per cycle (default eager(1))
-note [0rand7 4rand6]'stut(2rand4)
+note lead [0rand7 4rand6]'stut(2rand4)
 
 // count redrawn every 4 cycles
-note [0rand7 4rand6]'stut(2rand4'eager(4))
+note lead [0rand7 4rand6]'stut(2rand4'eager(4))
 ```
 
 How `'eager` and `'lock` apply to `'stut`:
 
-- Default (`'eager(1)`): stutter count is drawn once per cycle — `note [0rand7 4rand6]'stut(2rand4)`.
+- Default (`'eager(1)`): stutter count is drawn once per cycle — `note lead [0rand7 4rand6]'stut(2rand4)`.
 - `'stut(2rand4'eager(4))`: count is redrawn every 4 cycles.
 - `'stut(2rand4'lock)`: stutter count is chosen once and frozen forever.
 
@@ -167,11 +167,11 @@ The primary keyword specifies the _content type_ — what kind of events are gen
 | `slice`  | Beat-sliced buffer playback. (Behaviour defined in issue #14.)                                                                                         |
 | `cloud`  | Granular synthesis. (Behaviour defined in issue #14.)                                                                                                  |
 
-A space is required between the content type keyword and `[`.
+A name is required between the content type keyword and the generator expression (see "Generator naming" below). A space is required between the name and `[`.
 
 ```flux
-note [0 1 2 3]       // polyphonic pitched events, loops indefinitely
-mono [0 1 2 3]       // monophonic pitched events, loops indefinitely
+note lead [0 1 2 3]       // polyphonic pitched events, loops indefinitely
+mono bass [0 1 2 3]       // monophonic pitched events, loops indefinitely
 ```
 
 ### Timing
@@ -180,21 +180,21 @@ The duration of one cycle is always one `cycle`, as in TidalCycles. Each element
 
 ```flux
 // n = 4, each element gets 1/4 cycle
-note [0 1 2 3]
+note lead [0 1 2 3]
 
 // n = 6, each element gets 1/6 cycle
-note [0 1 2 3 4 5]
+note lead [0 1 2 3 4 5]
 
 // elements in sublists get slices of the parent's time slot
 // 0, 1 and 4 get 1/4 cycle; 2 and 3 each get 1/8 cycle (i.e. (1/4)/2)
-note [0 1 [2 3] 4]
+note lead [0 1 [2 3] 4]
 ```
 
 The `'offset` modifier schedules all events a number of milliseconds early (negative value) or late (positive value) relative to their normal trigger time. Equivalent to the `\lag` key in SC. Applies to all content types. See truth table [14 (`'offset`)](DSL-truthtables.md#14-offset-truth-table).
 
 ```flux
-note [0 1 2]'offset(20)    // all events 20 ms late
-note [0 1 2]'offset(-10)   // all events 10 ms early
+note lead [0 1 2]'offset(20)    // all events 20 ms late
+note lead [0 1 2]'offset(-10)   // all events 10 ms early
 ```
 
 ### Durations (`'legato`)
@@ -206,9 +206,9 @@ note [0 1 2]'offset(-10)   // all events 10 ms early
 Legato is a modifier, patternisable like any other stochastic argument:
 
 ```flux
-note [0 2 4 7]'legato(0.8)                  // fixed legato
-note [0 2 4 7]'legato(0.5rand1.2)            // stochastic legato, eager(1) by default
-note [0 2 4 7]'legato(0.5rand1.2'eager(4))  // new legato value every 4 cycles
+note lead [0 2 4 7]'legato(0.8)                  // fixed legato
+note lead [0 2 4 7]'legato(0.5rand1.2)            // stochastic legato, eager(1) by default
+note lead [0 2 4 7]'legato(0.5rand1.2'eager(4))  // new legato value every 4 cycles
 ```
 
 Legato values > 1.0 produce overlap (useful for pads/drones).
@@ -226,10 +226,10 @@ Structural length is frozen at the cycle boundary. All generators inside the lis
 By default all content types loop indefinitely. The `'n` modifier opts into finite playback:
 
 ```flux
-note [0 2 4]          // loop indefinitely (default)
-note [0 2 4]'n        // play once (equivalent to 'n(1))
-note [0 2 4]'n(1)     // play once
-note [0 2 4]'n(4)     // play 4 times
+note lead [0 2 4]          // loop indefinitely (default)
+note lead [0 2 4]'n        // play once (equivalent to 'n(1))
+note lead [0 2 4]'n(1)     // play once
+note lead [0 2 4]'n(4)     // play 4 times
 ```
 
 The count must be a positive integer ≥ 1. Zero, negative, or non-integer counts are semantic errors.
@@ -241,12 +241,12 @@ The count must be a positive integer ≥ 1. Zero, negative, or non-integer count
 `'at` applies to all content types and specifies the phase offset at which the pattern begins within the cycle. Useful for establishing phase relationships between patterns, and for scheduling finite runs at a specific point in time.
 
 ```flux
-note [0 2 4]'at(0)    // default: begins on the start of the next cycle
-note [0 2 4]'at(1)    // begin 1 cycle after the beginning of the next cycle
-note [0 2 4]'at(3/4)  // begin 3/4 cycle after the beginning of the next cycle
-note [0 2 4]'at(-1/8) // begin 1/8 cycle before the beginning of next cycle
-note [0 2 4]'at(1/2)  // loop, phase-shifted half a cycle
-note [0 2 4]'n'at(1/4) // play once, starting 1/4 cycle in
+note lead [0 2 4]'at(0)    // default: begins on the start of the next cycle
+note lead [0 2 4]'at(1)    // begin 1 cycle after the beginning of the next cycle
+note lead [0 2 4]'at(3/4)  // begin 3/4 cycle after the beginning of the next cycle
+note lead [0 2 4]'at(-1/8) // begin 1/8 cycle before the beginning of next cycle
+note lead [0 2 4]'at(1/2)  // loop, phase-shifted half a cycle
+note lead [0 2 4]'n'at(1/4) // play once, starting 1/4 cycle in
 ```
 
 If a pattern would be scheduled to start in the past, its start is postponed to the next cycle.
@@ -261,14 +261,14 @@ If a pattern would be scheduled to start in the past, its start is postponed to 
 The `@` operator schedules an element at an absolute position within the cycle (0 = cycle start, 1 = one full cycle). Positions are fractions, written the same way as everywhere else in the DSL:
 
 ```flux
-note [0@0 4@1/4 7@5/8]   // 0 at 0, 4 at 1/4 cycle, 7 at 5/8 cycle
+note lead [0@0 4@1/4 7@5/8]   // 0 at 0, 4 at 1/4 cycle, 7 at 5/8 cycle
 ```
 
 `@` is optional on individual elements. A bare degree keeps its natural uniform-spacing slot; only elements with `@` have their position overridden:
 
 ```flux
-note [0 4 7@1/2]   // 0 at 0, 4 at 1/3 (natural slot), 7 at 1/2 (override)
-note [0 2@1]       // 0 at 0 (natural), 2 at 1 (one full cycle in)
+note lead [0 4 7@1/2]   // 0 at 0, 4 at 1/3 (natural slot), 7 at 1/2 (override)
+note lead [0 2@1]       // 0 at 0 (natural), 2 at 1 (one full cycle in)
 ```
 
 ---
@@ -315,9 +315,9 @@ The `@cent` decorator remains available for fine-tuning but is not part of the c
 Modal transposition uses infix `+` and `-` operators on a content type expression:
 
 ```flux
-note [0 2 4] + 2        // shift all degrees up 2 scale steps
-note [0 2 4] - 1        // shift down 1 scale step
-note [0 2 4] + 0rand3   // stochastic transposition, eager(1) by default
+note lead [0 2 4] + 2        // shift all degrees up 2 scale steps
+note lead [0 2 4] - 1        // shift down 1 scale step
+note lead [0 2 4] + 0rand3   // stochastic transposition, eager(1) by default
 ```
 
 The right-hand side must be a non-negative scalar value or scalar generator. List generators (`[...]`) are not permitted as operands — two list generators combined arithmetically creates unresolvable stream-combination ambiguity. A double-negative such as `note [0] - -4` is a syntax error; use `note [0] + 4` instead.
@@ -362,17 +362,17 @@ Parameters: `scale`, `root`, `octave`, `tempo`, `cent`, `key`.
 
 ```flux
 @scale(\minor) @root(7)
-  note [0 1 2]
+  note lead [0 1 2]
   @octave(4)
-    note [0 2 4 5]
+    note lead [0 2 4 5]
 ```
 
-Here `note [0 1 2]` inherits `@scale(\minor)` and `@root(7)`. `note [0 2 4 5]` inherits all three, with `@octave(4)` added at the nested level.
+Here `note lead [0 1 2]` inherits `@scale(\minor)` and `@root(7)`. `note lead [0 2 4 5]` inherits all three, with `@octave(4)` added at the nested level.
 
 For single-expression use, decorators may appear inline on the same line:
 
 ```flux
-@scale(\minor) note [0 1 2]
+@scale(\minor) note lead [0 1 2]
 ```
 
 **`set` is `@` at global scope.** `set scale(\minor)` is sugar for a top-level `@scale(\minor)` with no indented body. They are the same mechanism at different scopes — `set` establishes session-wide defaults, `@` overrides them for a block.
@@ -406,9 +406,58 @@ String literals (`"moog"`) are not valid in Flux — use symbols instead.
 All content type keywords take exactly one optional `\symbol` argument to choose a SynthDef. The `\symbol` notation is required (not a bare identifier) to avoid name collisions with named generators.
 
 ```flux
-note(\moog) [0 1 2 3]'lfoRate(1/4)
-sample(\oneshot) [bd sn bd sn]
+note(\moog) lead [0 1 2 3]'lfoRate(1/4)
+sample(\oneshot) drums [bd sn bd sn]
 ```
+
+---
+
+## Generator naming
+
+Generators are named by placing an identifier between the content type keyword (and optional SynthDef argument) and the generator expression. A name is **mandatory** — unnamed generator expressions are a parse error.
+
+```flux
+note lead [0 2 4]
+sample drums [\kick \hat \snare]
+mono bass [0 -2 0 -3]
+note(\moog) lead [0 1 2 3]'lfoRate(1/4)
+```
+
+### Assignment semantics
+
+Generator naming is **assignment, not declaration**. Re-evaluating with the same name replaces the previous binding. The runtime diffs old and new state and updates in place where possible (e.g. `set` messages for `mono` content). Running synths are updated rather than killed and restarted — this preserves FX tails and avoids audible cuts. New synths are started for changed generator content where in-place update is not possible.
+
+**Duplicate names within a single evaluation are a static error**, detected before any audio changes are made:
+
+```flux
+// ERROR — two generators named "lead" in one evaluation
+note lead [0 2 4]
+note lead [0 4 7]
+```
+
+### Derived generators
+
+A named generator can be the parent of derived voices, using `child:parent` syntax:
+
+```flux
+sample drums [\kick \hat \snare]
+sample perc:drums 'at(1/8) | fx(\hpf)
+```
+
+`perc` inherits `drums`'s pattern and params, overriding only what's explicitly specified. The parent name is resolved at evaluation time. If `drums` is edited, `perc` re-derives.
+
+Derivation is always named — anonymous derived generators are not supported.
+
+**Removing a parent while derived generators still reference it is a static error**, detected before any audio changes are made. The user must remove or re-parent derived generators first:
+
+```flux
+// ERROR — "perc" references "drums" which is not present
+sample perc:drums 'at(1/8)
+```
+
+### FX ownership
+
+Named generators own their insert FX chains. Removing or redefining a named generator triggers drain-and-free: the FX synth runs until silence or a configurable timeout before being freed.
 
 ---
 
@@ -442,7 +491,7 @@ master_fx(\limiter)
 Scoped to a source pattern via the `|` pipe operator. Created when the source starts, released after a configurable silence tail when the source stops.
 
 ```flux
-note [0 2 4 7] | fx(\lpf)'cutoff([800 1200 2000 400]'eager)
+note lead [0 2 4 7] | fx(\lpf)'cutoff([800 1200 2000 400]'eager)
 ```
 
 The pipe operator implicitly passes the source as the audio input to the FX node — no explicit lambda required.
@@ -450,7 +499,7 @@ The pipe operator implicitly passes the source as the audio input to the FX node
 Silence tail duration for anonymous inserts is controlled via `'tail` on the `fx(...)` call (default TBD):
 
 ```flux
-note [0 2 4 7] | fx(\lpf)'cutoff(1200)'tail(4)  // release after 4s silence
+note lead [0 2 4 7] | fx(\lpf)'cutoff(1200)'tail(4)  // release after 4s silence
 ```
 
 ---
@@ -464,7 +513,7 @@ The sign `'` in an expression like `x'y` indicates a **modifier**, i.e. that `y`
 Modifiers are methods that return `this`, so chaining is supported:
 
 ```flux
-note [0rand7 4rand6]'eager'stut(2)
+note lead [0rand7 4rand6]'eager'stut(2)
 ```
 
 Modifiers attach to the **immediately preceding token**, not to the whole expression. This is the core rule governing modifier placement throughout the language.
@@ -491,18 +540,18 @@ Each generator is an independent stateful object. `'eager(n)` on a list propagat
 
 ```flux
 // draw new values on every cycle (explicit, same as default)
-note [0rand7 4]'eager(1)
+note lead [0rand7 4]'eager(1)
 // redraw every 4 cycles
-note [0 4rand6]'eager(4)
+note lead [0 4rand6]'eager(4)
 // frozen after first evaluation — each element locks at its own first-drawn value
-note [0rand7 4rand6]'lock
+note lead [0rand7 4rand6]'lock
 ```
 
 `'lock` and `'eager` can be used at whatever level of granularity is needed (list-level, element-level, modifier argument-level).
 
 ```flux
-note [0rand7 4rand6]'lock       // both elements lock at their own first-drawn values
-note [0rand7'lock 4rand6]       // first element locked, second draws every cycle (inner overrides outer)
+note lead [0rand7 4rand6]'lock       // both elements lock at their own first-drawn values
+note lead [0rand7'lock 4rand6]       // first element locked, second draws every cycle (inner overrides outer)
 ```
 
 ### Modifier continuation lines
@@ -510,7 +559,7 @@ note [0rand7'lock 4rand6]       // first element locked, second draws every cycl
 Because modifiers attach to the immediately preceding token, modifiers intended to apply to a whole content type expression (including its transposition operand) are written on an indented continuation line:
 
 ```flux
-note [0 2 4] + 0rand3
+note lead [0 2 4] + 0rand3
   'stut(2)
   'legato(0.8)
 ```

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -84,23 +84,23 @@ function collectFirst(source: string, numCycles: number): number[] {
 
 describe('createInstance — basic interface', () => {
 	it('returns ok:true for a valid pattern', () => {
-		expect(createInstance('note [0 2 4]').ok).toBe(true);
+		expect(createInstance('note x [0 2 4]').ok).toBe(true);
 	});
 
 	it('returns ok:false for parse errors', () => {
-		expect(createInstance('note [0 1 2').ok).toBe(false); // unclosed bracket
+		expect(createInstance('note x [0 1 2').ok).toBe(false); // unclosed bracket
 	});
 });
 
 describe('instance.evaluate — per-cycle output', () => {
 	it('produces one ScheduledEvent per list element', () => {
-		const res = inst('note [0 2 4]').evaluate({ cycleNumber: 0 });
+		const res = inst('note x [0 2 4]').evaluate({ cycleNumber: 0 });
 		if (!res.ok) throw new Error(res.error);
 		expect(res.events).toHaveLength(3);
 	});
 
 	it('each event has a note, beatOffset, and duration', () => {
-		const res = inst('note [0 2 4]').evaluate({ cycleNumber: 0 });
+		const res = inst('note x [0 2 4]').evaluate({ cycleNumber: 0 });
 		if (!res.ok) throw new Error(res.error);
 		for (const ev of res.events) {
 			expect(typeof ev.note).toBe('number');
@@ -110,7 +110,7 @@ describe('instance.evaluate — per-cycle output', () => {
 	});
 
 	it('distributes events evenly: 4 events → offsets 0, 0.25, 0.5, 0.75', () => {
-		const res = inst('note [0 1 2 3]').evaluate({ cycleNumber: 0 });
+		const res = inst('note x [0 1 2 3]').evaluate({ cycleNumber: 0 });
 		if (!res.ok) throw new Error(res.error);
 		expect(res.events[0].beatOffset).toBeCloseTo(0);
 		expect(res.events[1].beatOffset).toBeCloseTo(0.25);
@@ -126,18 +126,18 @@ describe('instance.evaluate — per-cycle output', () => {
 describe('eager(1) — resample at each cycle boundary (default)', () => {
 	it('step generator advances once per cycle (one-element list)', () => {
 		// 0step1x4 → degrees [0,1,2,3]. 4 cycles → 4 distinct values.
-		const ns = collectNotes('note [0step1x4]', 4);
+		const ns = collectNotes('note x [0step1x4]', 4);
 		expect(new Set(ns.map((c) => c[0])).size).toBe(4);
 	});
 
 	it('constant literal produces the same note every cycle', () => {
-		const ns = collectNotes('note [0]', 4);
+		const ns = collectNotes('note x [0]', 4);
 		const first = ns[0][0];
 		for (const cycle of ns) expect(cycle[0]).toBe(first);
 	});
 
 	it('value within a cycle is fixed — same cycleNumber returns same note', () => {
-		const i = inst('note [0step1x4]');
+		const i = inst('note x [0step1x4]');
 		const res0a = i.evaluate({ cycleNumber: 0 });
 		const res0b = i.evaluate({ cycleNumber: 0 });
 		if (!res0a.ok || !res0b.ok) throw new Error('eval failed');
@@ -147,21 +147,21 @@ describe('eager(1) — resample at each cycle boundary (default)', () => {
 
 describe("'lock — freeze on first sample", () => {
 	it("step generator with 'lock returns same value across all cycles", () => {
-		const ns = collectNotes("note [0step1x4'lock]", 4);
+		const ns = collectNotes("note x [0step1x4'lock]", 4);
 		const first = ns[0][0];
 		for (const cycle of ns) expect(cycle[0]).toBe(first);
 	});
 
 	it("'lock at list level freezes all elements independently", () => {
-		const ns = collectNotes("note [0step1x4 1step1x4]'lock", 4);
+		const ns = collectNotes("note x [0step1x4 1step1x4]'lock", 4);
 		expect(ns[1]).toEqual(ns[0]);
 		expect(ns[2]).toEqual(ns[0]);
 		expect(ns[3]).toEqual(ns[0]);
 	});
 
 	it("'lock and eager(1) produce different behaviour over multiple cycles", () => {
-		const withLock = collectNotes("note [0step1x4'lock]", 4);
-		const withEager = collectNotes('note [0step1x4]', 4);
+		const withLock = collectNotes("note x [0step1x4'lock]", 4);
+		const withEager = collectNotes('note x [0step1x4]', 4);
 		expect(new Set(withEager.map((c) => c[0])).size).toBe(4);
 		expect(new Set(withLock.map((c) => c[0])).size).toBe(1);
 	});
@@ -169,14 +169,14 @@ describe("'lock — freeze on first sample", () => {
 
 describe('eager(n) — resample every n cycles', () => {
 	it('eager(2): same value in cycles 0–1, new value at cycle 2, same in cycles 2–3', () => {
-		const ns = collectNotes("note [0step1x4'eager(2)]", 4);
+		const ns = collectNotes("note x [0step1x4'eager(2)]", 4);
 		expect(ns[0][0]).toBe(ns[1][0]);
 		expect(ns[2][0]).not.toBe(ns[0][0]);
 		expect(ns[2][0]).toBe(ns[3][0]);
 	});
 
 	it('eager(3): value constant for 3 cycles, then resamples at cycle 3', () => {
-		const ns = collectNotes("note [0step1x4'eager(3)]", 6);
+		const ns = collectNotes("note x [0step1x4'eager(3)]", 6);
 		expect(ns[0][0]).toBe(ns[1][0]);
 		expect(ns[1][0]).toBe(ns[2][0]);
 		expect(ns[3][0]).not.toBe(ns[0][0]);
@@ -185,44 +185,44 @@ describe('eager(n) — resample every n cycles', () => {
 	});
 
 	it('eager(1) on list propagates to elements as the default', () => {
-		const ns = collectNotes("note [0step1x4]'eager(1)", 4);
+		const ns = collectNotes("note x [0step1x4]'eager(1)", 4);
 		expect(new Set(ns.map((c) => c[0])).size).toBe(4);
 	});
 });
 
 describe('modifier precedence: inner overrides outer', () => {
 	it("inner 'lock beats outer eager(1) default — value frozen (truth table 2 row 1)", () => {
-		const ns = collectNotes("note [0step1x4'lock]", 4);
+		const ns = collectNotes("note x [0step1x4'lock]", 4);
 		const first = ns[0][0];
 		for (const cycle of ns) expect(cycle[0]).toBe(first);
 	});
 
 	it("inner 'lock beats outer 'eager(3) — value frozen (truth table 2 row 2)", () => {
-		const ns = collectNotes("note [0step1x4'lock]'eager(3)", 6);
+		const ns = collectNotes("note x [0step1x4'lock]'eager(3)", 6);
 		const first = ns[0][0];
 		for (const cycle of ns) expect(cycle[0]).toBe(first);
 	});
 
 	it("inner 'eager(2) beats outer 'lock — resamples every 2 (truth table 2 row 3)", () => {
-		const ns = collectNotes("note [0step1x4'eager(2)]'lock", 4);
+		const ns = collectNotes("note x [0step1x4'eager(2)]'lock", 4);
 		expect(ns[0][0]).toBe(ns[1][0]);
 		expect(ns[2][0]).not.toBe(ns[0][0]);
 	});
 
 	it("inner 'eager(2) beats outer 'eager(5) — resamples every 2 not every 5 (truth table 2 row 4)", () => {
-		const ns = collectNotes("note [0step1x4'eager(2)]'eager(5)", 4);
+		const ns = collectNotes("note x [0step1x4'eager(2)]'eager(5)", 4);
 		expect(ns[0][0]).toBe(ns[1][0]);
 		expect(ns[2][0]).not.toBe(ns[0][0]);
 	});
 
 	it("no inner annotation, outer 'lock applies — value frozen (truth table 2 row 5)", () => {
-		const ns = collectNotes("note [0step1x4]'lock", 4);
+		const ns = collectNotes("note x [0step1x4]'lock", 4);
 		const first = ns[0][0];
 		for (const cycle of ns) expect(cycle[0]).toBe(first);
 	});
 
 	it("no inner annotation, outer 'eager(2) applies — resamples every 2 cycles (truth table 2 row 6)", () => {
-		const ns = collectNotes("note [0step1x4]'eager(2)", 4);
+		const ns = collectNotes("note x [0step1x4]'eager(2)", 4);
 		expect(ns[0][0]).toBe(ns[1][0]);
 		expect(ns[2][0]).not.toBe(ns[0][0]);
 	});
@@ -234,12 +234,12 @@ describe('modifier precedence: inner overrides outer', () => {
 
 describe('numeric generators — degree-to-MIDI in C major / C5', () => {
 	it('negative degrees: degree -1 → B4 = MIDI 59, degree 0 → C5 = 60', () => {
-		expect(notes('note [-1 0]')).toEqual([59, 60]);
+		expect(notes('note x [-1 0]')).toEqual([59, 60]);
 	});
 
 	it('rand: all sampled degrees within [0, 4] map to valid C-major notes', () => {
 		const valid = new Set([60, 62, 64, 65, 67]);
-		const i = inst('note [0rand4]');
+		const i = inst('note x [0rand4]');
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -248,15 +248,15 @@ describe('numeric generators — degree-to-MIDI in C major / C5', () => {
 	});
 
 	it('rand: produces more than one distinct note over many cycles', () => {
-		expect(new Set(collectFirst('note [0rand6]', 100)).size).toBeGreaterThan(1);
+		expect(new Set(collectFirst('note x [0rand6]', 100)).size).toBeGreaterThan(1);
 	});
 
 	it('gau: produces varying notes (mean=3, sdev=1)', () => {
-		expect(new Set(collectFirst('note [3gau1]', 100)).size).toBeGreaterThan(1);
+		expect(new Set(collectFirst('note x [3gau1]', 100)).size).toBeGreaterThan(1);
 	});
 
 	it('exp: all notes within degree range [1, 7] → MIDI [62, 72]', () => {
-		const i = inst('note [1exp7]');
+		const i = inst('note x [1exp7]');
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -266,7 +266,7 @@ describe('numeric generators — degree-to-MIDI in C major / C5', () => {
 	});
 
 	it('bro: stays within degree range [0, 6] → MIDI [60, 71]', () => {
-		const i = inst('note [0bro6m1]');
+		const i = inst('note x [0bro6m1]');
 		for (let cycle = 0; cycle < 100; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -276,31 +276,31 @@ describe('numeric generators — degree-to-MIDI in C major / C5', () => {
 	});
 
 	it('bro: changes value over time (stateful)', () => {
-		expect(new Set(collectFirst('note [0bro6m2]', 50)).size).toBeGreaterThan(1);
+		expect(new Set(collectFirst('note x [0bro6m2]', 50)).size).toBeGreaterThan(1);
 	});
 
 	it('step: cycles through correct degrees — note [0step2x4]', () => {
 		// Pseries(start=0, step=2, length=4) → degrees [0, 2, 4, 6], repeating
 		// C major: C5=60, E5=64, G5=67, B5=71
-		expect(collectFirst('note [0step2x4]', 8)).toEqual([60, 64, 67, 71, 60, 64, 67, 71]);
+		expect(collectFirst('note x [0step2x4]', 8)).toEqual([60, 64, 67, 71, 60, 64, 67, 71]);
 	});
 
 	it('mul: cycles through correct degrees — note [1mul2x4]', () => {
 		// Pgeom(start=1, mul=2, length=4) → degrees [1, 2, 4, 8], repeating
 		// C major: D5=62, E5=64, G5=67, D6=74
-		expect(collectFirst('note [1mul2x4]', 5)).toEqual([62, 64, 67, 74, 62]);
+		expect(collectFirst('note x [1mul2x4]', 5)).toEqual([62, 64, 67, 74, 62]);
 	});
 
 	it('lin: spans from first to last degree — note [0lin4x3]', () => {
 		// linear interp first=0, last=4, length=3 → degrees [0, 2, 4]
 		// C major: C5=60, E5=64, G5=67
-		expect(collectFirst('note [0lin4x3]', 4)).toEqual([60, 64, 67, 60]); // wraps
+		expect(collectFirst('note x [0lin4x3]', 4)).toEqual([60, 64, 67, 60]); // wraps
 	});
 
 	it('geo: produces geometrically spaced degrees — note [1geo8x4]', () => {
 		// geometric interp first=1, last=8, length=4 → degrees [1, 2, 4, 8]
 		// C major: D5=62, E5=64, G5=67, D6=74
-		expect(collectFirst('note [1geo8x4]', 4)).toEqual([62, 64, 67, 74]);
+		expect(collectFirst('note x [1geo8x4]', 4)).toEqual([62, 64, 67, 74]);
 	});
 });
 
@@ -323,17 +323,17 @@ describe('rand / tilde — float bound semantics', () => {
 	it('integer bounds: Math.random()=0.0 → min', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0);
 		// floor(0 * (4 - 0 + 1)) + 0 = 0 → C5 = MIDI 60
-		expect(eval0('note [0rand4]')[0].note).toBe(60);
+		expect(eval0('note x [0rand4]')[0].note).toBe(60);
 	});
 
 	it('integer bounds: Math.random()=0.999 → max', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0.999);
 		// floor(0.999 * 5) + 0 = floor(4.995) = 4 → G5 = MIDI 67
-		expect(eval0('note [0rand4]')[0].note).toBe(67);
+		expect(eval0('note x [0rand4]')[0].note).toBe(67);
 	});
 
 	it('integer bounds: produces only integer degrees (never fractional MIDI)', () => {
-		const i = inst('note [0rand6]');
+		const i = inst('note x [0rand6]');
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -347,13 +347,13 @@ describe('rand / tilde — float bound semantics', () => {
 	it('float min, int max: Math.random()=0.0 → min exactly', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0);
 		// raw degree: 0.0 * (4 - 0.5) + 0.5 = 0.5 → Math.round(0.5) = 1 → D5 = MIDI 62
-		expect(eval0('note [0.5rand4]')[0].note).toBe(62);
+		expect(eval0('note x [0.5rand4]')[0].note).toBe(62);
 	});
 
 	it('float min, int max: Math.random()=1.0 → approaches max (open interval)', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(1 - Number.EPSILON);
 		// raw degree ≈ 3.5 - ε → Math.round ≈ 3 or 4 → MIDI in [62..67]
-		const note = eval0('note [0.5rand4]')[0].note;
+		const note = eval0('note x [0.5rand4]')[0].note;
 		expect(note).toBeGreaterThanOrEqual(62);
 		expect(note).toBeLessThanOrEqual(67);
 	});
@@ -362,7 +362,7 @@ describe('rand / tilde — float bound semantics', () => {
 		// 0.rand4 — min is 0.0 (trailing dot), max is 4
 		// continuous output in [0.0, 4.0) → degrees 0–4 reachable via Math.round
 		const valid = new Set([60, 62, 64, 65, 67]);
-		const i = inst('note [0.rand4]');
+		const i = inst('note x [0.rand4]');
 		for (let cycle = 0; cycle < 100; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -375,13 +375,13 @@ describe('rand / tilde — float bound semantics', () => {
 	it('int min, float max: Math.random()=0.0 → min exactly', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0);
 		// raw degree: 0.0 * (3.5 - 0) + 0 = 0.0 → Math.round(0) = 0 → C5 = MIDI 60
-		expect(eval0('note [0rand3.5]')[0].note).toBe(60);
+		expect(eval0('note x [0rand3.5]')[0].note).toBe(60);
 	});
 
 	it('int min, float max: all sampled degrees round to valid C-major notes', () => {
 		// 0rand3.5 — output in [0.0, 3.5) rounds to degree 0–3 → MIDI [60, 62, 64, 65]
 		const valid = new Set([60, 62, 64, 65]);
-		const i = inst('note [0rand3.5]');
+		const i = inst('note x [0rand3.5]');
 		for (let cycle = 0; cycle < 100; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -394,38 +394,38 @@ describe('rand / tilde — float bound semantics', () => {
 	it('both float bounds: Math.random()=0.0 → min exactly', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0);
 		// raw degree: 0.0 * (3.5 - 0.5) + 0.5 = 0.5 → Math.round(0.5) = 1 → D5 = MIDI 62
-		expect(eval0('note [0.5rand3.5]')[0].note).toBe(62);
+		expect(eval0('note x [0.5rand3.5]')[0].note).toBe(62);
 	});
 
 	it('both float bounds: Math.random()=0.5 → midpoint', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0.5);
 		// raw degree: 0.5 * (3.5 - 0.5) + 0.5 = 1.5 + 0.5 = 2.0 → Math.round(2.0) = 2 → E5 = MIDI 64
-		expect(eval0('note [0.5rand3.5]')[0].note).toBe(64);
+		expect(eval0('note x [0.5rand3.5]')[0].note).toBe(64);
 	});
 
 	it('both float bounds: produces more than one distinct note over many cycles', () => {
-		expect(new Set(collectFirst('note [0.5rand3.5]', 100)).size).toBeGreaterThan(1);
+		expect(new Set(collectFirst('note x [0.5rand3.5]', 100)).size).toBeGreaterThan(1);
 	});
 
 	// --- Tilde (~) — syntactic sugar for rand ---
 
 	it('tilde with integer bounds: Math.random()=0.0 → min', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0);
-		expect(eval0('note [0~4]')[0].note).toBe(60);
+		expect(eval0('note x [0~4]')[0].note).toBe(60);
 	});
 
 	it('tilde with float min: Math.random()=0.0 → same result as float rand', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0);
-		const noteRand = eval0('note [0.5rand4]')[0].note;
+		const noteRand = eval0('note x [0.5rand4]')[0].note;
 		// fresh instance (mock still active)
 		vi.spyOn(Math, 'random').mockReturnValue(0);
-		const noteTilde = eval0('note [0.5~4]')[0].note;
+		const noteTilde = eval0('note x [0.5~4]')[0].note;
 		expect(noteTilde).toBe(noteRand);
 	});
 
 	it('tilde with float max: all sampled degrees in valid range', () => {
 		const valid = new Set([60, 62, 64, 65]);
-		const i = inst('note [0~3.5]');
+		const i = inst('note x [0~3.5]');
 		for (let cycle = 0; cycle < 100; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -436,7 +436,7 @@ describe('rand / tilde — float bound semantics', () => {
 	// --- Edge cases ---
 
 	it('min === max (float): always returns min', () => {
-		const i = inst('note [2.5rand2.5]');
+		const i = inst('note x [2.5rand2.5]');
 		for (let cycle = 0; cycle < 10; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -446,7 +446,7 @@ describe('rand / tilde — float bound semantics', () => {
 	});
 
 	it('min === max (integer): always returns that degree', () => {
-		const i = inst('note [3rand3]');
+		const i = inst('note x [3rand3]');
 		for (let cycle = 0; cycle < 10; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -458,7 +458,7 @@ describe('rand / tilde — float bound semantics', () => {
 	it('negative float min: Math.random()=0.0 → min degree (rounds correctly)', () => {
 		vi.spyOn(Math, 'random').mockReturnValue(0);
 		// raw degree: -0.5 → Math.round(-0.5) = 0 → C5 = MIDI 60
-		expect(eval0('note [-0.5rand2]')[0].note).toBe(60);
+		expect(eval0('note x [-0.5rand2]')[0].note).toBe(60);
 	});
 
 	it('negative float min: all sampled notes within expected range', () => {
@@ -467,7 +467,7 @@ describe('rand / tilde — float bound semantics', () => {
 		// so degree -1 is unreachable. Reachable degrees: 0, 1, 2.
 		// C major: C5=60, D5=62, E5=64
 		const valid = new Set([60, 62, 64]);
-		const i = inst('note [-0.5rand2]');
+		const i = inst('note x [-0.5rand2]');
 		for (let cycle = 0; cycle < 100; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -480,7 +480,7 @@ describe('rand / tilde — float bound semantics', () => {
 		// [2.5rand4] → rounds to 3 or 4 → F5=65 or G5=67
 		const validFirst = new Set([62, 64]);
 		const validSecond = new Set([65, 67]);
-		const i = inst('note [0.5rand2 2.5rand4]');
+		const i = inst('note x [0.5rand2 2.5rand4]');
 		for (let cycle = 0; cycle < 100; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -498,151 +498,151 @@ describe('rand / tilde — float bound semantics', () => {
 // ---------------------------------------------------------------------------
 
 describe('default pitch context — C major / C5 (baseline)', () => {
-	it('degree 0 = C5 = MIDI 60', () => expect(notes('note [0]')[0]).toBe(60));
-	it('degree 1 = D5 = MIDI 62', () => expect(notes('note [1]')[0]).toBe(62));
-	it('degree 4 = G5 = MIDI 67', () => expect(notes('note [4]')[0]).toBe(67));
-	it('degree 7 = C6 = MIDI 72 (octave wrap)', () => expect(notes('note [7]')[0]).toBe(72));
-	it('degree -1 = B4 = MIDI 59 (below root)', () => expect(notes('note [-1]')[0]).toBe(59));
+	it('degree 0 = C5 = MIDI 60', () => expect(notes('note x [0]')[0]).toBe(60));
+	it('degree 1 = D5 = MIDI 62', () => expect(notes('note x [1]')[0]).toBe(62));
+	it('degree 4 = G5 = MIDI 67', () => expect(notes('note x [4]')[0]).toBe(67));
+	it('degree 7 = C6 = MIDI 72 (octave wrap)', () => expect(notes('note x [7]')[0]).toBe(72));
+	it('degree -1 = B4 = MIDI 59 (below root)', () => expect(notes('note x [-1]')[0]).toBe(59));
 });
 
 describe('@root — changes root pitch class (semitone offset from C)', () => {
 	it('@root(7) shifts root to G: degree 0 = G5 = MIDI 67', () => {
-		expect(notes('@root(7) note [0]')[0]).toBe(67);
+		expect(notes('@root(7) note x [0]')[0]).toBe(67);
 	});
 
 	it('@root(7) degree 1 in major = A5 = MIDI 69', () => {
 		// G5=67 + 2 semitones = 69
-		expect(notes('@root(7) note [1]')[0]).toBe(69);
+		expect(notes('@root(7) note x [1]')[0]).toBe(69);
 	});
 
 	it('@root(0) is same as default (C)', () => {
-		expect(notes('@root(0) note [0]')[0]).toBe(60);
+		expect(notes('@root(0) note x [0]')[0]).toBe(60);
 	});
 
 	it('@root(2) shifts to D: degree 0 = D5 = MIDI 62', () => {
-		expect(notes('@root(2) note [0]')[0]).toBe(62);
+		expect(notes('@root(2) note x [0]')[0]).toBe(62);
 	});
 });
 
 describe('@octave — changes the octave', () => {
 	it('@octave(4) lowers by one octave: C4 = MIDI 48', () => {
-		expect(notes('@octave(4) note [0]')[0]).toBe(48);
+		expect(notes('@octave(4) note x [0]')[0]).toBe(48);
 	});
 
 	it('@octave(6) raises by one octave: C6 = MIDI 72', () => {
-		expect(notes('@octave(6) note [0]')[0]).toBe(72);
+		expect(notes('@octave(6) note x [0]')[0]).toBe(72);
 	});
 
 	it('@octave(5) is the default: C5 = MIDI 60', () => {
-		expect(notes('@octave(5) note [0]')[0]).toBe(60);
+		expect(notes('@octave(5) note x [0]')[0]).toBe(60);
 	});
 
 	it('@octave(3) deep bass: C3 = MIDI 36', () => {
-		expect(notes('@octave(3) note [0]')[0]).toBe(36);
+		expect(notes('@octave(3) note x [0]')[0]).toBe(36);
 	});
 });
 
 describe('@scale — changes the active scale', () => {
 	// minor intervals: [2,1,2,2,1,2,2] → degree 2 = 3 semitones from root → Eb5 = 63
 	it('@scale(minor) degree 2 = Eb5 = MIDI 63', () => {
-		expect(notes('@scale(minor) note [2]')[0]).toBe(63);
+		expect(notes('@scale(minor) note x [2]')[0]).toBe(63);
 	});
 
 	it('@scale(major) degree 2 = E5 = MIDI 64 (same as default)', () => {
-		expect(notes('@scale(major) note [2]')[0]).toBe(64);
+		expect(notes('@scale(major) note x [2]')[0]).toBe(64);
 	});
 
 	// major_pentatonic: [2,2,3,2,3] → degree 2 = 4 semitones → E5 = 64
 	it('@scale(major_pentatonic) degree 2 = E5 = MIDI 64', () => {
-		expect(notes('@scale(major_pentatonic) note [2]')[0]).toBe(64);
+		expect(notes('@scale(major_pentatonic) note x [2]')[0]).toBe(64);
 	});
 
 	// minor_pentatonic: [3,2,2,3,2] → degree 1 = 3 semitones → Eb5 = 63
 	it('@scale(minor_pentatonic) degree 1 = Eb5 = MIDI 63', () => {
-		expect(notes('@scale(minor_pentatonic) note [1]')[0]).toBe(63);
+		expect(notes('@scale(minor_pentatonic) note x [1]')[0]).toBe(63);
 	});
 
 	// dorian: [2,1,2,2,2,1,2] → degree 6 = 10 semitones → Bb5 = 70
 	it('@scale(dorian) degree 6 = Bb5 = MIDI 70', () => {
-		expect(notes('@scale(dorian) note [6]')[0]).toBe(70);
+		expect(notes('@scale(dorian) note x [6]')[0]).toBe(70);
 	});
 
 	// phrygian: [1,2,2,2,1,2,2] → degree 1 = 1 semitone → Db5 = 61
 	it('@scale(phrygian) degree 1 = Db5 = MIDI 61', () => {
-		expect(notes('@scale(phrygian) note [1]')[0]).toBe(61);
+		expect(notes('@scale(phrygian) note x [1]')[0]).toBe(61);
 	});
 
 	// lydian: [2,2,2,1,2,2,1] → degree 3 = 6 semitones → F#5 = 66
 	it('@scale(lydian) degree 3 = F#5 = MIDI 66', () => {
-		expect(notes('@scale(lydian) note [3]')[0]).toBe(66);
+		expect(notes('@scale(lydian) note x [3]')[0]).toBe(66);
 	});
 
 	// mixolydian: [2,2,1,2,2,1,2] → degree 6 = 10 semitones → Bb5 = 70
 	it('@scale(mixolydian) degree 6 = Bb5 = MIDI 70', () => {
-		expect(notes('@scale(mixolydian) note [6]')[0]).toBe(70);
+		expect(notes('@scale(mixolydian) note x [6]')[0]).toBe(70);
 	});
 
 	// locrian: [1,2,2,1,2,2,2] → degree 4 = 6 semitones → F#5 = 66
 	it('@scale(locrian) degree 4 = F#5 = MIDI 66', () => {
-		expect(notes('@scale(locrian) note [4]')[0]).toBe(66);
+		expect(notes('@scale(locrian) note x [4]')[0]).toBe(66);
 	});
 
 	// harmonic_minor: [2,1,2,2,1,3,1] → degree 6 = 11 semitones → B5 = 71
 	it('@scale(harmonic_minor) degree 6 = B5 = MIDI 71', () => {
-		expect(notes('@scale(harmonic_minor) note [6]')[0]).toBe(71);
+		expect(notes('@scale(harmonic_minor) note x [6]')[0]).toBe(71);
 	});
 
 	// melodic_minor: [2,1,2,2,2,2,1] → degree 5 = 9 semitones → A5 = 69
 	it('@scale(melodic_minor) degree 5 = A5 = MIDI 69', () => {
-		expect(notes('@scale(melodic_minor) note [5]')[0]).toBe(69);
+		expect(notes('@scale(melodic_minor) note x [5]')[0]).toBe(69);
 	});
 
 	// harmonic_major: [2,2,1,2,1,3,1] → degree 5 = 8 semitones → Ab5 = 68
 	it('@scale(harmonic_major) degree 5 = Ab5 = MIDI 68', () => {
-		expect(notes('@scale(harmonic_major) note [5]')[0]).toBe(68);
+		expect(notes('@scale(harmonic_major) note x [5]')[0]).toBe(68);
 	});
 
 	// blues: [3,2,1,1,3,2] → degree 2 = 5 semitones → F5 = 65
 	it('@scale(blues) degree 2 = F5 = MIDI 65', () => {
-		expect(notes('@scale(blues) note [2]')[0]).toBe(65);
+		expect(notes('@scale(blues) note x [2]')[0]).toBe(65);
 	});
 
 	// whole_tone: [2,2,2,2,2,2] → degree 3 = 6 semitones → F#5 = 66
 	it('@scale(whole_tone) degree 3 = F#5 = MIDI 66', () => {
-		expect(notes('@scale(whole_tone) note [3]')[0]).toBe(66);
+		expect(notes('@scale(whole_tone) note x [3]')[0]).toBe(66);
 	});
 
 	// diminished: [2,1,2,1,2,1,2,1] → degree 4 = 6 semitones → F#5 = 66
 	it('@scale(diminished) degree 4 = F#5 = MIDI 66', () => {
-		expect(notes('@scale(diminished) note [4]')[0]).toBe(66);
+		expect(notes('@scale(diminished) note x [4]')[0]).toBe(66);
 	});
 
 	// augmented: [3,1,3,1,3,1] → degree 2 = 4 semitones → E5 = 64
 	it('@scale(augmented) degree 2 = E5 = MIDI 64', () => {
-		expect(notes('@scale(augmented) note [2]')[0]).toBe(64);
+		expect(notes('@scale(augmented) note x [2]')[0]).toBe(64);
 	});
 });
 
 describe('@cent — pitch deviation in cents', () => {
 	it('@cent(0) no deviation: note number is still 60 (cent offset is separate metadata)', () => {
-		expect(notes('@cent(0) note [0]')[0]).toBe(60);
+		expect(notes('@cent(0) note x [0]')[0]).toBe(60);
 	});
 
 	it('@cent(50) stores a non-zero cent offset on events', () => {
-		const res = inst('@cent(50) note [0]').evaluate({ cycleNumber: 0 });
+		const res = inst('@cent(50) note x [0]').evaluate({ cycleNumber: 0 });
 		if (!res.ok) throw new Error(res.error);
 		expect(res.events[0].note).toBe(60);
 		expect(res.events[0].cent).toBe(50);
 	});
 
 	it('@cent(-50) stores a negative cent offset', () => {
-		const res = inst('@cent(-50) note [0]').evaluate({ cycleNumber: 0 });
+		const res = inst('@cent(-50) note x [0]').evaluate({ cycleNumber: 0 });
 		if (!res.ok) throw new Error(res.error);
 		expect(res.events[0].cent).toBe(-50);
 	});
 
 	it('no @cent decorator → cent defaults to 0', () => {
-		const res = inst('note [0]').evaluate({ cycleNumber: 0 });
+		const res = inst('note x [0]').evaluate({ cycleNumber: 0 });
 		if (!res.ok) throw new Error(res.error);
 		expect(res.events[0].cent ?? 0).toBe(0);
 	});
@@ -651,158 +651,158 @@ describe('@cent — pitch deviation in cents', () => {
 describe('@key — compound decorator (root + scale [+ octave])', () => {
 	it('@key(g lydian) degree 0 = G5 = MIDI 67', () => {
 		// rootMidi = 60 + 7 = 67. Lydian degree 0 = 0 → MIDI 67
-		expect(notes('@key(g lydian) note [0]')[0]).toBe(67);
+		expect(notes('@key(g lydian) note x [0]')[0]).toBe(67);
 	});
 
 	it('@key(g lydian) degree 3 = C#6 = MIDI 73', () => {
 		// Lydian: [2,2,2,1,2,2,1] → offset at degree 3 = 6 → 67+6 = 73
-		expect(notes('@key(g lydian) note [3]')[0]).toBe(73);
+		expect(notes('@key(g lydian) note x [3]')[0]).toBe(73);
 	});
 
 	it('@key(g# lydian) degree 0 = G#5 = MIDI 68', () => {
 		// rootMidi = 60 + 8 = 68
-		expect(notes('@key(g# lydian) note [0]')[0]).toBe(68);
+		expect(notes('@key(g# lydian) note x [0]')[0]).toBe(68);
 	});
 
 	it('@key(a minor) degree 0 = A5 = MIDI 69', () => {
 		// rootMidi = 60 + 9 = 69
-		expect(notes('@key(a minor) note [0]')[0]).toBe(69);
+		expect(notes('@key(a minor) note x [0]')[0]).toBe(69);
 	});
 
 	it('@key(a minor) degree 2 = C6 = MIDI 72', () => {
 		// A5=69, minor[2] = 3 semitones → 72
-		expect(notes('@key(a minor) note [2]')[0]).toBe(72);
+		expect(notes('@key(a minor) note x [2]')[0]).toBe(72);
 	});
 
 	it('@key(c major 4) degree 0 = C4 = MIDI 48', () => {
 		// rootMidi = 60 + 0 - 12 = 48
-		expect(notes('@key(c major 4) note [0]')[0]).toBe(48);
+		expect(notes('@key(c major 4) note x [0]')[0]).toBe(48);
 	});
 
 	it('@key(c major 6) degree 0 = C6 = MIDI 72', () => {
-		expect(notes('@key(c major 6) note [0]')[0]).toBe(72);
+		expect(notes('@key(c major 6) note x [0]')[0]).toBe(72);
 	});
 
 	it('@key(bb major) degree 0 = Bb5 = MIDI 70', () => {
 		// rootMidi = 60 + 10 = 70
-		expect(notes('@key(bb major) note [0]')[0]).toBe(70);
+		expect(notes('@key(bb major) note x [0]')[0]).toBe(70);
 	});
 
 	it('@key(G lydian) (uppercase) degree 0 = G5 = MIDI 67', () => {
-		expect(notes('@key(G lydian) note [0]')[0]).toBe(67);
+		expect(notes('@key(G lydian) note x [0]')[0]).toBe(67);
 	});
 });
 
 describe('set — writes to global context', () => {
 	it('set scale(minor) changes default scale globally', () => {
 		// minor degree 2 = 3 semitones → Eb5 = 63
-		expect(notes('set scale(minor)\nnote [2]')[0]).toBe(63);
+		expect(notes('set scale(minor)\nnote x [2]')[0]).toBe(63);
 	});
 
 	it('set root(7) shifts root to G globally', () => {
-		expect(notes('set root(7)\nnote [0]')[0]).toBe(67);
+		expect(notes('set root(7)\nnote x [0]')[0]).toBe(67);
 	});
 
 	it('set octave(4) lowers octave globally', () => {
-		expect(notes('set octave(4)\nnote [0]')[0]).toBe(48);
+		expect(notes('set octave(4)\nnote x [0]')[0]).toBe(48);
 	});
 
 	it('set key(g lydian) applies compound decorator globally', () => {
-		expect(notes('set key(g lydian)\nnote [0]')[0]).toBe(67);
+		expect(notes('set key(g lydian)\nnote x [0]')[0]).toBe(67);
 	});
 
 	it('multiple set statements combine', () => {
 		// set root(7) + set octave(4): G4 = 60 + 7 - 12 = 55
-		expect(notes('set root(7)\nset octave(4)\nnote [0]')[0]).toBe(55);
+		expect(notes('set root(7)\nset octave(4)\nnote x [0]')[0]).toBe(55);
 	});
 });
 
 describe('decorator scoping (truth table 8)', () => {
-	it('block body inherits outer decorator: @scale(minor) note [2] = Eb5 = 63', () => {
-		expect(notes('@scale(minor)\n  note [2]')[0]).toBe(63);
+	it('block body inherits outer decorator: @scale(minor) note x [2] = Eb5 = 63', () => {
+		expect(notes('@scale(minor)\n  note x [2]')[0]).toBe(63);
 	});
 
-	it('inline decorator: @scale(minor) note [2] = Eb5 = 63', () => {
-		expect(notes('@scale(minor) note [2]')[0]).toBe(63);
+	it('inline decorator: @scale(minor) note x [2] = Eb5 = 63', () => {
+		expect(notes('@scale(minor) note x [2]')[0]).toBe(63);
 	});
 
 	it('no decorator: note [0] uses global defaults → C5 = 60', () => {
-		expect(notes('note [0]')[0]).toBe(60);
+		expect(notes('note x [0]')[0]).toBe(60);
 	});
 
 	it('@key(g# lydian) inline: degree 0 = G#5 = 68', () => {
-		expect(notes('@key(g# lydian) note [0]')[0]).toBe(68);
+		expect(notes('@key(g# lydian) note x [0]')[0]).toBe(68);
 	});
 
 	it('@key(g# lydian 4) inline: degree 0 = G#4 = 56', () => {
-		expect(notes('@key(g# lydian 4) note [0]')[0]).toBe(56);
+		expect(notes('@key(g# lydian 4) note x [0]')[0]).toBe(56);
 	});
 
 	it('nested @root(7) outer, @scale(minor) inner: both apply — G minor degree 2 = Bb5 = 70', () => {
 		// G5=67, minor degree 2 = 3 semitones → 70
-		expect(notes('@root(7)\n  @scale(minor)\n    note [2]')[0]).toBe(70);
+		expect(notes('@root(7)\n  @scale(minor)\n    note x [2]')[0]).toBe(70);
 	});
 
 	it('inner @root overrides outer @root', () => {
 		// outer @root(7) = G, inner @root(0) = C → C5 = 60
-		expect(notes('@root(7)\n  @root(0)\n    note [0]')[0]).toBe(60);
+		expect(notes('@root(7)\n  @root(0)\n    note x [0]')[0]).toBe(60);
 	});
 
 	it('decorator scope is lexical — does not affect undecorated siblings', () => {
 		// Two patterns: one under @scale(minor), one bare. At minimum parses successfully.
-		expect(createInstance('@scale(minor)\n  note [2]\nnote [2]').ok).toBe(true);
+		expect(createInstance('@scale(minor)\n  note x [2]\nnote y [2]').ok).toBe(true);
 	});
 });
 
 describe('set vs @ interaction', () => {
 	it('@ overrides set for its scope', () => {
 		// set root(7): global G. @root(0) overrides to C for the inline loop.
-		expect(notes('set root(7)\n@root(0) note [0]')[0]).toBe(60);
+		expect(notes('set root(7)\n@root(0) note x [0]')[0]).toBe(60);
 	});
 
 	it('set applies when no @ override', () => {
-		expect(notes('set root(7)\nnote [0]')[0]).toBe(67);
+		expect(notes('set root(7)\nnote x [0]')[0]).toBe(67);
 	});
 });
 
 describe('stochastic decorator arguments', () => {
 	it('@root with constant generator: @root(7) is the same as a literal', () => {
-		expect(notes('@root(7) note [0]')[0]).toBe(67);
+		expect(notes('@root(7) note x [0]')[0]).toBe(67);
 	});
 
 	it('@root with step generator: lock-by-default freezes root at first value', () => {
 		// @root(0step7x2) — decorators lock by default, so root is frozen at 0 (= C5).
-		const ns = collectFirst('@root(0step7x2) note [0]', 4);
+		const ns = collectFirst('@root(0step7x2) note x [0]', 4);
 		expect(ns.every((n) => n === ns[0])).toBe(true);
 		expect(ns[0]).toBe(60); // locked at step start value 0 → C5
 	});
 });
 
 describe('multiple inline decorators on same pattern', () => {
-	it('@scale(minor) @root(7) note [0]: G minor, degree 0 = G5 = 67', () => {
-		expect(notes('@scale(minor) @root(7) note [0]')[0]).toBe(67);
+	it('@scale(minor) @root(7) note x [0]: G minor, degree 0 = G5 = 67', () => {
+		expect(notes('@scale(minor) @root(7) note x [0]')[0]).toBe(67);
 	});
 
-	it('@scale(minor) @root(7) note [2]: G minor degree 2 = Bb5 = 70', () => {
+	it('@scale(minor) @root(7) note x [2]: G minor degree 2 = Bb5 = 70', () => {
 		// G5=67, minor[2] = 3 semitones → 70
-		expect(notes('@scale(minor) @root(7) note [2]')[0]).toBe(70);
+		expect(notes('@scale(minor) @root(7) note x [2]')[0]).toBe(70);
 	});
 });
 
 describe('pitch chain: combined root + octave + scale', () => {
 	it('root=5 (F), octave=4, major, degree 0 = F4 = MIDI 53', () => {
 		// F5=65, F4=53
-		expect(notes('@root(5) @octave(4) note [0]')[0]).toBe(53);
+		expect(notes('@root(5) @octave(4) note x [0]')[0]).toBe(53);
 	});
 
 	it('root=7 (G), major, degree 2 = B5 = MIDI 71', () => {
 		// G5=67, major degree 2 = 4 semitones → 71
-		expect(notes('@root(7) note [2]')[0]).toBe(71);
+		expect(notes('@root(7) note x [2]')[0]).toBe(71);
 	});
 
 	it('@key(g minor) degree 7 wraps to G6 = MIDI 79', () => {
 		// G5=67, degree 7 = 12 semitones up (full octave) → 79
-		expect(notes('@key(g minor) note [7]')[0]).toBe(79);
+		expect(notes('@key(g minor) note x [7]')[0]).toBe(79);
 	});
 });
 
@@ -821,15 +821,17 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	const SHIFT = -5;
 
 	it('literal degree: [2] in G major/4 → E4 = 59', () => {
-		expect(notes('@key(g major 4) note [2]')[0]).toBe(64 + SHIFT);
+		expect(notes('@key(g major 4) note x [2]')[0]).toBe(64 + SHIFT);
 	});
 
 	it('literal list: [0 2 4 6] in G major/4 — all four notes shifted -5', () => {
-		expect(notes('@key(g major 4) note [0 2 4 6]')).toEqual([60, 64, 67, 71].map((n) => n + SHIFT));
+		expect(notes('@key(g major 4) note x [0 2 4 6]')).toEqual(
+			[60, 64, 67, 71].map((n) => n + SHIFT)
+		);
 	});
 
 	it('step: [0step2x4] advances through degrees 0,2,4,6 across 4 cycles in G major/4', () => {
-		const i = inst('@key(g major 4) note [0step2x4]');
+		const i = inst('@key(g major 4) note x [0step2x4]');
 		const cycleNotes = [0, 1, 2, 3].map((c) => {
 			const res = i.evaluate({ cycleNumber: c });
 			if (!res.ok) throw new Error(res.error);
@@ -839,7 +841,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	});
 
 	it('mul: [1mul2x4] advances through degrees 1,2,4,8 across 4 cycles in G major/4', () => {
-		const i = inst('@key(g major 4) note [1mul2x4]');
+		const i = inst('@key(g major 4) note x [1mul2x4]');
 		const cycleNotes = [0, 1, 2, 3].map((c) => {
 			const res = i.evaluate({ cycleNumber: c });
 			if (!res.ok) throw new Error(res.error);
@@ -849,7 +851,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	});
 
 	it('lin: [0lin4x3] advances through degrees 0,2,4 across 3 cycles in G major/4', () => {
-		const i = inst('@key(g major 4) note [0lin4x3]');
+		const i = inst('@key(g major 4) note x [0lin4x3]');
 		const cycleNotes = [0, 1, 2].map((c) => {
 			const res = i.evaluate({ cycleNumber: c });
 			if (!res.ok) throw new Error(res.error);
@@ -859,7 +861,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	});
 
 	it('geo: [1geo8x4] advances through degrees 1,2,4,8 across 4 cycles in G major/4', () => {
-		const i = inst('@key(g major 4) note [1geo8x4]');
+		const i = inst('@key(g major 4) note x [1geo8x4]');
 		const cycleNotes = [0, 1, 2, 3].map((c) => {
 			const res = i.evaluate({ cycleNumber: c });
 			if (!res.ok) throw new Error(res.error);
@@ -870,7 +872,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 
 	it('rand: [0rand4] in G major/4 — all notes in shifted G-major range', () => {
 		const validInG = new Set([60, 62, 64, 65, 67].map((n) => n + SHIFT));
-		const i = inst('@key(g major 4) note [0rand4]');
+		const i = inst('@key(g major 4) note x [0rand4]');
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -879,7 +881,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	});
 
 	it('rand: [0rand4] in G major/4 — produces more than one distinct note', () => {
-		const i = inst('@key(g major 4) note [0rand4]');
+		const i = inst('@key(g major 4) note x [0rand4]');
 		const seen = new Set<number>();
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
@@ -891,7 +893,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 
 	it('tilde (~): [0~4] in G major/4 — all notes in shifted range', () => {
 		const validInG = new Set([60, 62, 64, 65, 67].map((n) => n + SHIFT));
-		const i = inst('@key(g major 4) note [0~4]');
+		const i = inst('@key(g major 4) note x [0~4]');
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -900,7 +902,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	});
 
 	it('gau: [3gau1] in G major/4 — varies and is lower than C major/5 equivalent', () => {
-		const i = inst('@key(g major 4) note [3gau1]');
+		const i = inst('@key(g major 4) note x [3gau1]');
 		const seen = new Set<number>();
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
@@ -914,7 +916,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 
 	it('exp: [1exp7] in G major/4 — all notes in shifted range [57, 67]', () => {
 		// C/5: degrees 1–7 → MIDI 62–72. G/4: -5 → 57–67.
-		const i = inst('@key(g major 4) note [1exp7]');
+		const i = inst('@key(g major 4) note x [1exp7]');
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -924,7 +926,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	});
 
 	it('bro: [0bro6m1] in G major/4 — stays within shifted degree range [55, 66]', () => {
-		const i = inst('@key(g major 4) note [0bro6m1]');
+		const i = inst('@key(g major 4) note x [0bro6m1]');
 		for (let cycle = 0; cycle < 100; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -936,7 +938,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 	it('step in minor: [0step1x3] in A minor/5 advances A5→B5→C6', () => {
 		// A minor root=9, octave=5 → rootMidi=69. minor intervals: [2,1,2,2,1,2,2]
 		// degree 0→69(A5), degree 1→71(B5), degree 2→72(C6)
-		const i = inst('@key(a minor) note [0step1x3]');
+		const i = inst('@key(a minor) note x [0step1x3]');
 		const cycleNotes = [0, 1, 2].map((c) => {
 			const res = i.evaluate({ cycleNumber: c });
 			if (!res.ok) throw new Error(res.error);
@@ -949,7 +951,7 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 		// D dorian: root=2, octave=5 → rootMidi=62. dorian intervals: [2,1,2,2,2,1,2]
 		// degrees 0–4 offsets: [0,2,3,5,7] → MIDI [62,64,65,67,69]
 		const validDDorian = new Set([62, 64, 65, 67, 69]);
-		const i = inst('@key(d dorian) note [0rand4]');
+		const i = inst('@key(d dorian) note x [0rand4]');
 		for (let cycle = 0; cycle < 50; cycle++) {
 			const res = i.evaluate({ cycleNumber: cycle });
 			if (!res.ok) throw new Error(res.error);
@@ -959,13 +961,13 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 
 	it('multi-element list in non-default context: all elements shifted', () => {
 		// C/5: [0 2 4] → [60, 64, 67]. G/4: → [55, 59, 62]
-		expect(notes('@key(g major 4) note [0 2 4]')).toEqual([55, 59, 62]);
+		expect(notes('@key(g major 4) note x [0 2 4]')).toEqual([55, 59, 62]);
 	});
 
 	it('set root(9) + step: note [0step1x3] advances A5→B5→C#6', () => {
 		// A major root=9 → rootMidi=69. major intervals: [2,2,1,2,2,2,1]
 		// degree 0→69, degree 1→71, degree 2→73
-		const i = inst('set root(9)\nnote [0step1x3]');
+		const i = inst('set root(9)\nnote x [0step1x3]');
 		const cycleNotes = [0, 1, 2].map((c) => {
 			const res = i.evaluate({ cycleNumber: c });
 			if (!res.ok) throw new Error(res.error);
@@ -982,11 +984,11 @@ describe('generators × non-default pitch context (@key(g major 4), shift = -5)'
 describe("'stut — stutter (truth table 3)", () => {
 	it("bare 'stut defaults to stut(2): N×2 events", () => {
 		// 2 elements × 2 repetitions = 4 events
-		expect(eval0("note [0 2]'stut")).toHaveLength(4);
+		expect(eval0("note x [0 2]'stut")).toHaveLength(4);
 	});
 
 	it("'stut repeats each element in order: [0,0,2,2]", () => {
-		const ns = notes("note [0 2]'stut");
+		const ns = notes("note x [0 2]'stut");
 		expect(ns[0]).toBe(ns[1]); // first element repeated
 		expect(ns[2]).toBe(ns[3]); // second element repeated
 		expect(ns[0]).not.toBe(ns[2]);
@@ -994,13 +996,13 @@ describe("'stut — stutter (truth table 3)", () => {
 
 	it('each stutter event gets 1/(N×k) of the cycle as duration', () => {
 		// note [0 2]'stut(2) → 4 events, each 1/4
-		const ds = durations("note [0 2]'stut(2)");
+		const ds = durations("note x [0 2]'stut(2)");
 		expect(ds).toHaveLength(4);
 		for (const d of ds) expect(d).toBeCloseTo(0.25);
 	});
 
 	it('beat offsets are evenly spaced across full cycle', () => {
-		const os = offsets("note [0 2]'stut(2)");
+		const os = offsets("note x [0 2]'stut(2)");
 		expect(os[0]).toBeCloseTo(0);
 		expect(os[1]).toBeCloseTo(0.25);
 		expect(os[2]).toBeCloseTo(0.5);
@@ -1008,19 +1010,19 @@ describe("'stut — stutter (truth table 3)", () => {
 	});
 
 	it("'stut(4) repeats each element 4 times", () => {
-		const evs = eval0("note [0]'stut(4)");
+		const evs = eval0("note x [0]'stut(4)");
 		expect(evs).toHaveLength(4);
 		expect(new Set(evs.map((e) => e.note)).size).toBe(1);
 	});
 
 	it('within a cycle, adjacent stutter events share the same note', () => {
-		const evs = eval0("note [0 2]'stut(2)");
+		const evs = eval0("note x [0 2]'stut(2)");
 		expect(evs[0].note).toBe(evs[1].note);
 		expect(evs[2].note).toBe(evs[3].note);
 	});
 
 	it("'stut(2rand4'lock) freezes the count across all cycles", () => {
-		const i = inst("note [0]'stut(2rand4'lock)");
+		const i = inst("note x [0]'stut(2rand4'lock)");
 		const counts: number[] = [];
 		for (let c = 0; c < 5; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1033,7 +1035,7 @@ describe("'stut — stutter (truth table 3)", () => {
 	});
 
 	it("'stut(2rand4'eager(4)) redraws count every 4 cycles", () => {
-		const i = inst("note [0]'stut(2rand4'eager(4))");
+		const i = inst("note x [0]'stut(2rand4'eager(4))");
 		const counts: number[] = [];
 		for (let c = 0; c < 8; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1049,14 +1051,14 @@ describe("'stut — stutter (truth table 3)", () => {
 	});
 
 	it("'stut(0) is clamped to 1 (no crash)", () => {
-		expect(eval0("note [0]'stut(0)").length).toBeGreaterThanOrEqual(1);
+		expect(eval0("note x [0]'stut(0)").length).toBeGreaterThanOrEqual(1);
 	});
 });
 
 describe("'wran — weighted random pick (truth table 4)", () => {
 	it('uniform weights: all three values appear across many samples', () => {
 		vi.spyOn(Math, 'random').mockRestore();
-		const i = inst("note [0 2 4]'wran");
+		const i = inst("note x [0 2 4]'wran");
 		const seen = new Set<number>();
 		for (let c = 0; c < 50; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1067,7 +1069,7 @@ describe("'wran — weighted random pick (truth table 4)", () => {
 	});
 
 	it('element with weight 3 appears more often than element with weight 1', () => {
-		const i = inst("note [0?3 4?1]'wran");
+		const i = inst("note x [0?3 4?1]'wran");
 		const counts = { n0: 0, n4: 0 };
 		for (let c = 0; c < 100; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1080,7 +1082,7 @@ describe("'wran — weighted random pick (truth table 4)", () => {
 	});
 
 	it('zero weight removes element: only the non-zero-weight element appears', () => {
-		const i = inst("note [0?0 4?1]'wran");
+		const i = inst("note x [0?0 4?1]'wran");
 		const seen = new Set<number>();
 		for (let c = 0; c < 20; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1094,7 +1096,7 @@ describe("'wran — weighted random pick (truth table 4)", () => {
 
 describe("'pick — random element selection", () => {
 	it('picks a random element each cycle (at least 2 distinct values over 50 cycles)', () => {
-		const i = inst("note [0 2 4]'pick");
+		const i = inst("note x [0 2 4]'pick");
 		const seen = new Set<number>();
 		for (let c = 0; c < 50; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1107,7 +1109,7 @@ describe("'pick — random element selection", () => {
 
 describe("'shuf — shuffle traversal", () => {
 	it('shuffles elements but still emits all of them per cycle', () => {
-		const i = inst("note [0 2 4]'shuf");
+		const i = inst("note x [0 2 4]'shuf");
 		for (let c = 0; c < 5; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			if (!r.ok) throw new Error(r.error);
@@ -1124,7 +1126,7 @@ describe("'shuf — shuffle traversal", () => {
 describe("'maybe — probability filter (truth table 5)", () => {
 	it("bare 'maybe defaults to p=0.5: some events pass, some are skipped", () => {
 		vi.spyOn(Math, 'random').mockRestore();
-		const i = inst("note [0 2 4 0 2 4 0 2 4 0]'maybe");
+		const i = inst("note x [0 2 4 0 2 4 0 2 4 0]'maybe");
 		let total = 0;
 		for (let c = 0; c < 20; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1136,21 +1138,21 @@ describe("'maybe — probability filter (truth table 5)", () => {
 	});
 
 	it("'maybe(1.0) passes all events", () => {
-		expect(eval0("note [0 2 4]'maybe(1.0)")).toHaveLength(3);
+		expect(eval0("note x [0 2 4]'maybe(1.0)")).toHaveLength(3);
 	});
 
 	it("'maybe(0.0) skips all events — returns empty array", () => {
-		expect(eval0("note [0 2 4]'maybe(0.0)")).toHaveLength(0);
+		expect(eval0("note x [0 2 4]'maybe(0.0)")).toHaveLength(0);
 	});
 
 	it('empty event array is ok:true (not an error)', () => {
-		const r = inst("note [0 2 4]'maybe(0.0)").evaluate({ cycleNumber: 0 });
+		const r = inst("note x [0 2 4]'maybe(0.0)").evaluate({ cycleNumber: 0 });
 		expect(r.ok).toBe(true);
 		if (r.ok) expect(r.events).toHaveLength(0);
 	});
 
 	it("'maybe(0.5rand1.0) uses stochastic probability — 0 to N events", () => {
-		const r = inst("note [0 2 4]'maybe(0.5rand1.0)").evaluate({ cycleNumber: 0 });
+		const r = inst("note x [0 2 4]'maybe(0.5rand1.0)").evaluate({ cycleNumber: 0 });
 		expect(r.ok).toBe(true);
 		if (r.ok) {
 			expect(r.events.length).toBeGreaterThanOrEqual(0);
@@ -1162,23 +1164,23 @@ describe("'maybe — probability filter (truth table 5)", () => {
 describe("'legato — duration scaling (truth table 13)", () => {
 	it("'legato(0.8) sets duration = 0.8 × slot", () => {
 		// note [0 2 4] → 3 elements, slot = 1/3
-		for (const d of durations("note [0 2 4]'legato(0.8)")) expect(d).toBeCloseTo((1 / 3) * 0.8);
+		for (const d of durations("note x [0 2 4]'legato(0.8)")) expect(d).toBeCloseTo((1 / 3) * 0.8);
 	});
 
 	it("'legato(1.0) — duration equals slot exactly", () => {
-		for (const d of durations("note [0 2 4]'legato(1.0)")) expect(d).toBeCloseTo(1 / 3);
+		for (const d of durations("note x [0 2 4]'legato(1.0)")) expect(d).toBeCloseTo(1 / 3);
 	});
 
 	it("'legato(1.5) — duration exceeds slot (notes overlap)", () => {
-		for (const d of durations("note [0 2 4]'legato(1.5)")) expect(d).toBeCloseTo((1 / 3) * 1.5);
+		for (const d of durations("note x [0 2 4]'legato(1.5)")) expect(d).toBeCloseTo((1 / 3) * 1.5);
 	});
 
 	it("default legato is 1.0 when no 'legato modifier", () => {
-		for (const d of durations('note [0 2 4]')) expect(d).toBeCloseTo(1 / 3);
+		for (const d of durations('note x [0 2 4]')) expect(d).toBeCloseTo(1 / 3);
 	});
 
 	it("'legato(0.5rand1.2) draws once per cycle — all events in cycle share same duration", () => {
-		const r = inst("note [0 2 4]'legato(0.5rand1.2)").evaluate({ cycleNumber: 0 });
+		const r = inst("note x [0 2 4]'legato(0.5rand1.2)").evaluate({ cycleNumber: 0 });
 		if (!r.ok) throw new Error(r.error);
 		const ds = r.events.map((e) => e.duration);
 		expect(ds[0]).toBeCloseTo(ds[1]);
@@ -1186,7 +1188,7 @@ describe("'legato — duration scaling (truth table 13)", () => {
 	});
 
 	it("'legato(0.5rand1.2'lock) freezes legato value across cycles", () => {
-		const i = inst("note [0 2 4]'legato(0.5rand1.2'lock)");
+		const i = inst("note x [0 2 4]'legato(0.5rand1.2'lock)");
 		const r0 = i.evaluate({ cycleNumber: 0 });
 		const r5 = i.evaluate({ cycleNumber: 5 });
 		if (!r0.ok || !r5.ok) throw new Error('eval failed');
@@ -1194,7 +1196,7 @@ describe("'legato — duration scaling (truth table 13)", () => {
 	});
 
 	it("'legato(0.5rand1.2'eager(2)) redraws every 2 cycles", () => {
-		const i = inst("note [0]'legato(0.5rand1.2'eager(2))");
+		const i = inst("note x [0]'legato(0.5rand1.2'eager(2))");
 		const d = (c: number) => {
 			const r = i.evaluate({ cycleNumber: c });
 			if (!r.ok) throw new Error(r.error);
@@ -1207,24 +1209,24 @@ describe("'legato — duration scaling (truth table 13)", () => {
 
 describe("'offset — ms timing shift (truth table 14)", () => {
 	it("'offset(20) adds offsetMs=20 to all events", () => {
-		for (const e of eval0("note [0 1 2]'offset(20)"))
+		for (const e of eval0("note x [0 1 2]'offset(20)"))
 			expect((e as { offsetMs?: number }).offsetMs).toBe(20);
 	});
 
 	it("'offset(-10) adds offsetMs=-10 to all events", () => {
-		for (const e of eval0("note [0 1 2]'offset(-10)"))
+		for (const e of eval0("note x [0 1 2]'offset(-10)"))
 			expect((e as { offsetMs?: number }).offsetMs).toBe(-10);
 	});
 
 	it("'offset(0) adds offsetMs=0 (or leaves it absent)", () => {
-		for (const e of eval0("note [0 1 2]'offset(0)")) {
+		for (const e of eval0("note x [0 1 2]'offset(0)")) {
 			const ms = (e as { offsetMs?: number }).offsetMs;
 			expect(ms === undefined || ms === 0).toBe(true);
 		}
 	});
 
 	it("beatOffset positions are not changed by 'offset", () => {
-		const evs = eval0("note [0 1 2]'offset(20)");
+		const evs = eval0("note x [0 1 2]'offset(20)");
 		expect(evs[0].beatOffset).toBeCloseTo(0);
 		expect(evs[1].beatOffset).toBeCloseTo(1 / 3);
 		expect(evs[2].beatOffset).toBeCloseTo(2 / 3);
@@ -1232,24 +1234,24 @@ describe("'offset — ms timing shift (truth table 14)", () => {
 });
 
 describe('mono content type (truth table 16)', () => {
-	it('mono [0 1 2] — all events have mono:true', () => {
-		for (const e of eval0('mono [0 1 2]')) expect((e as { mono?: boolean }).mono).toBe(true);
+	it('mono x [0 1 2] — all events have mono:true', () => {
+		for (const e of eval0('mono x [0 1 2]')) expect((e as { mono?: boolean }).mono).toBe(true);
 	});
 
-	it('note [0 1 2] without mono — mono field absent or false', () => {
-		for (const e of eval0('note [0 1 2]')) {
+	it('note x [0 1 2] without mono — mono field absent or false', () => {
+		for (const e of eval0('note x [0 1 2]')) {
 			const m = (e as { mono?: boolean }).mono;
 			expect(m === undefined || m === false).toBe(true);
 		}
 	});
 
-	it('mono [0 2 4] — all events have mono:true', () => {
-		for (const e of eval0('mono [0 2 4]')) expect((e as { mono?: boolean }).mono).toBe(true);
+	it('mono x [0 2 4] — all events have mono:true', () => {
+		for (const e of eval0('mono x [0 2 4]')) expect((e as { mono?: boolean }).mono).toBe(true);
 	});
 
 	it('mono content type does not affect note or timing', () => {
-		const normal = eval0('note [0 2 4]');
-		const mono = eval0('mono [0 2 4]');
+		const normal = eval0('note x [0 2 4]');
+		const mono = eval0('mono x [0 2 4]');
 		expect(mono.map((e) => e.note)).toEqual(normal.map((e) => e.note));
 		expect(mono.map((e) => e.beatOffset)).toEqual(normal.map((e) => e.beatOffset));
 	});
@@ -1263,55 +1265,55 @@ describe('accidentals (truth table 15)', () => {
 	// Default context: C major, C5. Accidentals apply a semitone offset to the
 	// MIDI result (after scale lookup).
 	it('[2b] = degree 2 flat: one semitone below E5 → Eb5 = 63', () => {
-		expect(notes('note [2b]')[0]).toBe(notes('note [2]')[0] - 1);
+		expect(notes('note x [2b]')[0]).toBe(notes('note x [2]')[0] - 1);
 	});
 
 	it('[4#] = degree 4 sharp: one semitone above G5 → G#5 = 68', () => {
-		expect(notes('note [4#]')[0]).toBe(notes('note [4]')[0] + 1);
+		expect(notes('note x [4#]')[0]).toBe(notes('note x [4]')[0] + 1);
 	});
 
 	it('[3bb] = degree 3 double flat: two semitones below F5 → Eb5 = 63', () => {
-		expect(notes('note [3bb]')[0]).toBe(notes('note [3]')[0] - 2);
+		expect(notes('note x [3bb]')[0]).toBe(notes('note x [3]')[0] - 2);
 	});
 
 	it('[4##] = degree 4 double sharp: two semitones above G5 → A5 = 69', () => {
-		expect(notes('note [4##]')[0]).toBe(notes('note [4]')[0] + 2);
+		expect(notes('note x [4##]')[0]).toBe(notes('note x [4]')[0] + 2);
 	});
 
 	it('[0 2b 4] — mixed list: C5, Eb5, G5', () => {
-		expect(notes('note [0 2b 4]')).toEqual([60, 63, 67]);
+		expect(notes('note x [0 2b 4]')).toEqual([60, 63, 67]);
 	});
 
 	it('accidentals work with non-default scale context', () => {
 		// @key(g major): root=G5=67, G major scale. degree 2 = B5 = 71.
 		// degree 2b = B5 - 1 = Bb5 = 70.
-		expect(notes('@key(g major) note [2b]')[0]).toBe(notes('@key(g major) note [2]')[0] - 1);
+		expect(notes('@key(g major) note x [2b]')[0]).toBe(notes('@key(g major) note x [2]')[0] - 1);
 	});
 });
 
 describe('transposition (truth table 10)', () => {
-	it('note [0 2] + 3 adds 3 scale steps to each degree', () => {
+	it('note x [0 2] + 3 adds 3 scale steps to each degree', () => {
 		// degree 0+3=3 → F5=65, degree 2+3=5 → A5=69
-		expect(notes('note [0 2] + 3')).toEqual([65, 69]);
+		expect(notes('note x [0 2] + 3')).toEqual([65, 69]);
 	});
 
-	it('note [0 2] - 1 subtracts 1 scale step', () => {
+	it('note x [0 2] - 1 subtracts 1 scale step', () => {
 		// degree 2-1=1 → D5=62
-		expect(notes('note [0 2] - 1')[1]).toBe(62);
+		expect(notes('note x [0 2] - 1')[1]).toBe(62);
 	});
 
 	it('transposition with 0 is identity', () => {
-		expect(notes('note [0 2 4] + 0')).toEqual(notes('note [0 2 4]'));
+		expect(notes('note x [0 2 4] + 0')).toEqual(notes('note x [0 2 4]'));
 	});
 
-	it('note [0] + 0rand3 uses a stochastic transpose — produces 1 event per cycle', () => {
-		const r = inst('note [0] + 0rand3').evaluate({ cycleNumber: 0 });
+	it('note x [0] + 0rand3 uses a stochastic transpose — produces 1 event per cycle', () => {
+		const r = inst('note x [0] + 0rand3').evaluate({ cycleNumber: 0 });
 		expect(r.ok).toBe(true);
 		if (r.ok) expect(r.events).toHaveLength(1);
 	});
 
 	it("'lock on transposition RHS freezes value across cycles", () => {
-		const i = inst("note [0] + 0step1x4'lock");
+		const i = inst("note x [0] + 0step1x4'lock");
 		const r0 = i.evaluate({ cycleNumber: 0 });
 		const r1 = i.evaluate({ cycleNumber: 1 });
 		const r2 = i.evaluate({ cycleNumber: 2 });
@@ -1321,8 +1323,8 @@ describe('transposition (truth table 10)', () => {
 	});
 
 	it('transposition participates in full pitch chain', () => {
-		// @key(g major) note [0] + 2 should equal @key(g major) note [2]
-		expect(notes('@key(g major) note [0] + 2')[0]).toBe(notes('@key(g major) note [2]')[0]);
+		// @key(g major) note x [0] + 2 should equal @key(g major) note x [2]
+		expect(notes('@key(g major) note x [0] + 2')[0]).toBe(notes('@key(g major) note x [2]')[0]);
 	});
 });
 
@@ -1331,47 +1333,47 @@ describe('transposition (truth table 10)', () => {
 // ---------------------------------------------------------------------------
 
 describe("note'n statement (truth table 7)", () => {
-	it("note [0 1 2]'n produces correct notes", () => {
-		expect(notes("note [0 1 2]'n")).toEqual([60, 62, 64]);
+	it("note x [0 1 2]'n produces correct notes", () => {
+		expect(notes("note x [0 1 2]'n")).toEqual([60, 62, 64]);
 	});
 
 	it("note'n timing: N elements → beatOffset 0, 1/N, 2/N, …", () => {
-		const evs = eval0("note [0 1 2]'n");
+		const evs = eval0("note x [0 1 2]'n");
 		expect(evs[0].beatOffset).toBeCloseTo(0);
 		expect(evs[1].beatOffset).toBeCloseTo(1 / 3);
 		expect(evs[2].beatOffset).toBeCloseTo(2 / 3);
 	});
 
-	it("note [0 1]'n'at(1/4) sets cycleOffset=0.25 on all events", () => {
-		for (const e of eval0("note [0 1]'n'at(1/4)"))
+	it("note x [0 1]'n'at(1/4) sets cycleOffset=0.25 on all events", () => {
+		for (const e of eval0("note x [0 1]'n'at(1/4)"))
 			expect((e as { cycleOffset?: number }).cycleOffset).toBeCloseTo(0.25);
 	});
 
-	it("note [0 1]'n'at(0) sets cycleOffset=0 (default)", () => {
-		for (const e of eval0("note [0 1]'n'at(0)")) {
+	it("note x [0 1]'n'at(0) sets cycleOffset=0 (default)", () => {
+		for (const e of eval0("note x [0 1]'n'at(0)")) {
 			const co = (e as { cycleOffset?: number }).cycleOffset;
 			expect(co === undefined || co === 0).toBe(true);
 		}
 	});
 
-	it("note [0]'n'at(-1/4) sets cycleOffset=-0.25", () => {
-		const co = (eval0("note [0]'n'at(-1/4)")[0] as { cycleOffset?: number }).cycleOffset;
+	it("note x [0]'n'at(-1/4) sets cycleOffset=-0.25", () => {
+		const co = (eval0("note x [0]'n'at(-1/4)")[0] as { cycleOffset?: number }).cycleOffset;
 		expect(co).toBeCloseTo(-0.25);
 	});
 
 	it("'at shifts when the note starts; beatOffset stays relative to that start", () => {
-		const evs = eval0("note [0 1 2]'n'at(1/4)");
+		const evs = eval0("note x [0 1 2]'n'at(1/4)");
 		expect(evs[0].beatOffset).toBeCloseTo(0);
 		expect(evs[1].beatOffset).toBeCloseTo(1 / 3);
 		expect(evs[2].beatOffset).toBeCloseTo(2 / 3);
 	});
 
-	it("note [0 1]'n(4) emits 2×4 = 8 events", () => {
-		expect(eval0("note [0 1]'n(4)")).toHaveLength(8);
+	it("note x [0 1]'n(4) emits 2×4 = 8 events", () => {
+		expect(eval0("note x [0 1]'n(4)")).toHaveLength(8);
 	});
 
 	it("'n events span multiple cycles: cycleOffset increments by 1 per repetition", () => {
-		const cycleOffsets = eval0("note [0]'n(3)").map(
+		const cycleOffsets = eval0("note x [0]'n(3)").map(
 			(e) => (e as { cycleOffset?: number }).cycleOffset ?? 0
 		);
 		expect(cycleOffsets[0]).toBeCloseTo(0);
@@ -1380,27 +1382,27 @@ describe("note'n statement (truth table 7)", () => {
 	});
 
 	it("bare 'n plays once and does not crash", () => {
-		expect(inst("note [0]'n").evaluate({ cycleNumber: 0 }).ok).toBe(true);
+		expect(inst("note x [0]'n").evaluate({ cycleNumber: 0 }).ok).toBe(true);
 	});
 
 	it("note'n supports pitch context decorators", () => {
-		// @key(g major) note [0]'n → G5 = 67
-		expect(notes("@key(g major) note [0]'n")[0]).toBe(67);
+		// @key(g major) note x [0]'n → G5 = 67
+		expect(notes("@key(g major) note x [0]'n")[0]).toBe(67);
 	});
 
 	it("integer 'at on continuation line", () => {
-		const co = (eval0("note [0 1]'n\n  'at(1)")[0] as { cycleOffset?: number }).cycleOffset;
+		const co = (eval0("note x [0 1]'n\n  'at(1)")[0] as { cycleOffset?: number }).cycleOffset;
 		expect(co).toBeCloseTo(1);
 	});
 
-	it("note [0 1 2]'n returns done:false on cycle 0 (the one cycle it runs)", () => {
-		const r = inst("note [0 1 2]'n").evaluate({ cycleNumber: 0 });
+	it("note x [0 1 2]'n returns done:false on cycle 0 (the one cycle it runs)", () => {
+		const r = inst("note x [0 1 2]'n").evaluate({ cycleNumber: 0 });
 		expect(r.ok).toBe(true);
 		if (r.ok) expect(r.done).toBe(false);
 	});
 
-	it("note [0 1 2]'n returns done:true on cycle 1 (played once, finished)", () => {
-		const i = inst("note [0 1 2]'n");
+	it("note x [0 1 2]'n returns done:true on cycle 1 (played once, finished)", () => {
+		const i = inst("note x [0 1 2]'n");
 		i.evaluate({ cycleNumber: 0 }); // consume cycle 0
 		const r = i.evaluate({ cycleNumber: 1 });
 		expect(r.ok).toBe(true);
@@ -1410,8 +1412,8 @@ describe("note'n statement (truth table 7)", () => {
 		}
 	});
 
-	it("note [0]'n'at(2) is not done until after cycle 2", () => {
-		const i = inst("note [0]'n'at(2)");
+	it("note x [0]'n'at(2) is not done until after cycle 2", () => {
+		const i = inst("note x [0]'n'at(2)");
 		const r0 = i.evaluate({ cycleNumber: 0 });
 		expect(r0.ok && !r0.done).toBe(true);
 		const r2 = i.evaluate({ cycleNumber: 2 });
@@ -1420,8 +1422,8 @@ describe("note'n statement (truth table 7)", () => {
 		expect(r3.ok && r3.done).toBe(true);
 	});
 
-	it("note [0]'n(3) is done after its 3 cycles", () => {
-		const i = inst("note [0]'n(3)");
+	it("note x [0]'n(3) is done after its 3 cycles", () => {
+		const i = inst("note x [0]'n(3)");
 		for (let c = 0; c < 3; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			expect(r.ok && !r.done).toBe(true);
@@ -1430,8 +1432,8 @@ describe("note'n statement (truth table 7)", () => {
 		expect(r.ok && r.done).toBe(true);
 	});
 
-	it('note [0 1 2] loops indefinitely, never returns done:true', () => {
-		const i = inst('note [0 1 2]');
+	it('note x [0 1 2] loops indefinitely, never returns done:true', () => {
+		const i = inst('note x [0 1 2]');
 		for (let c = 0; c < 5; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			expect(r.ok).toBe(true);
@@ -1442,15 +1444,16 @@ describe("note'n statement (truth table 7)", () => {
 
 describe('modifier continuation lines (truth table 1)', () => {
 	it("continuation 'stut attaches to pattern", () => {
-		expect(eval0("note [0 2]\n  'stut(2)")).toHaveLength(4);
+		expect(eval0("note x [0 2]\n  'stut(2)")).toHaveLength(4);
 	});
 
 	it("continuation 'legato attaches to pattern", () => {
-		for (const d of durations("note [0 2 4]\n  'legato(0.8)")) expect(d).toBeCloseTo((1 / 3) * 0.8);
+		for (const d of durations("note x [0 2 4]\n  'legato(0.8)"))
+			expect(d).toBeCloseTo((1 / 3) * 0.8);
 	});
 
 	it('multiple continuation modifiers on separate lines', () => {
-		const evs = eval0("note [0 2]\n  'stut(2)\n  'legato(0.8)");
+		const evs = eval0("note x [0 2]\n  'stut(2)\n  'legato(0.8)");
 		expect(evs).toHaveLength(4);
 		for (const e of evs) expect(e.duration).toBeCloseTo(0.25 * 0.8);
 	});
@@ -1461,8 +1464,8 @@ describe('modifier continuation lines (truth table 1)', () => {
 // ---------------------------------------------------------------------------
 
 describe('FX pipe (truth table 9)', () => {
-	it('note [0] | fx(\\lpf) — result includes exactly one FxEvent', () => {
-		const r = inst('note [0] | fx(\\lpf)').evaluate({ cycleNumber: 0 });
+	it('note x [0] | fx(\\lpf) — result includes exactly one FxEvent', () => {
+		const r = inst('note x [0] | fx(\\lpf)').evaluate({ cycleNumber: 0 });
 		expect(r.ok).toBe(true);
 		if (!r.ok) return;
 		const fxEvents = r.events.filter((e) => (e as { type?: string }).type === 'fx');
@@ -1470,8 +1473,8 @@ describe('FX pipe (truth table 9)', () => {
 		expect((fxEvents[0] as { synthdef?: string }).synthdef).toBe('lpf');
 	});
 
-	it('note [0] | fx(\\lpf) — note events are still present', () => {
-		const r = inst('note [0] | fx(\\lpf)').evaluate({ cycleNumber: 0 });
+	it('note x [0] | fx(\\lpf) — note events are still present', () => {
+		const r = inst('note x [0] | fx(\\lpf)').evaluate({ cycleNumber: 0 });
 		if (!r.ok) throw new Error(r.error);
 		const noteEvents = r.events.filter((e) => (e as { type?: string }).type !== 'fx');
 		expect(noteEvents).toHaveLength(1);
@@ -1479,7 +1482,7 @@ describe('FX pipe (truth table 9)', () => {
 	});
 
 	it("fx event has type:'fx', synthdef, params, cycleOffset", () => {
-		const r = inst('note [0] | fx(\\lpf)').evaluate({ cycleNumber: 0 });
+		const r = inst('note x [0] | fx(\\lpf)').evaluate({ cycleNumber: 0 });
 		if (!r.ok) throw new Error(r.error);
 		const fxEv = r.events.find((e) => (e as { type?: string }).type === 'fx') as {
 			type: string;
@@ -1495,7 +1498,7 @@ describe('FX pipe (truth table 9)', () => {
 	});
 
 	it('fx modifier params are included in fx event params', () => {
-		const r = inst("note [0] | fx(\\lpf)'cutoff(1200)").evaluate({ cycleNumber: 0 });
+		const r = inst("note x [0] | fx(\\lpf)'cutoff(1200)").evaluate({ cycleNumber: 0 });
 		if (!r.ok) throw new Error(r.error);
 		const fxEv = r.events.find((e) => (e as { type?: string }).type === 'fx') as {
 			params: Record<string, number>;
@@ -1505,7 +1508,7 @@ describe('FX pipe (truth table 9)', () => {
 	});
 
 	it("fx modifier params respect 'lock semantics", () => {
-		const i = inst("note [0] | fx(\\lpf)'cutoff(800rand1600'lock)");
+		const i = inst("note x [0] | fx(\\lpf)'cutoff(800rand1600'lock)");
 		const r0 = i.evaluate({ cycleNumber: 0 });
 		const r1 = i.evaluate({ cycleNumber: 1 });
 		if (!r0.ok || !r1.ok) throw new Error('eval failed');
@@ -1526,7 +1529,7 @@ describe('FX pipe (truth table 9)', () => {
 describe("'stut + 'legato interaction", () => {
 	it("'stut(2)'legato(0.8): expanded slots × legato factor = 0.25 × 0.8", () => {
 		// note [0 2]'stut(2) → 4 events, slot=0.25. 'legato(0.8) → duration = 0.2
-		const ds = durations("note [0 2]'stut(2)'legato(0.8)");
+		const ds = durations("note x [0 2]'stut(2)'legato(0.8)");
 		expect(ds).toHaveLength(4);
 		for (const d of ds) expect(d).toBeCloseTo(0.25 * 0.8);
 	});
@@ -1543,43 +1546,43 @@ describe("'stut + 'legato interaction", () => {
 describe("'stut edge cases", () => {
 	it("'stut(-1) is clamped to 1 — same output as no stut", () => {
 		// Negative count: Math.max(1, round(-1)) = 1
-		expect(eval0("note [0 2]'stut(-1)")).toHaveLength(2);
+		expect(eval0("note x [0 2]'stut(-1)")).toHaveLength(2);
 	});
 
 	it("'stut([1 2]) — list arg: stut is ignored, elements render normally", () => {
 		// '[1 2] is not a scalar generator so extractModifierScalar returns null;
 		// stutRunner stays null → stutCount defaults to 1.
-		expect(eval0("note [0]'stut([1 2])")).toHaveLength(2);
+		expect(eval0("note x [0]'stut([1 2])")).toHaveLength(2);
 	});
 });
 
 describe("'legato edge cases", () => {
 	it("'legato(0) produces events with duration 0", () => {
-		for (const d of durations("note [0 2]'legato(0)")) expect(d).toBe(0);
+		for (const d of durations("note x [0 2]'legato(0)")) expect(d).toBe(0);
 	});
 
 	it("'legato(-0.5) produces events with negative duration (gate opens before slot)", () => {
-		for (const d of durations("note [0 2]'legato(-0.5)")) expect(d).toBeCloseTo(-0.5 * 0.5);
+		for (const d of durations("note x [0 2]'legato(-0.5)")) expect(d).toBeCloseTo(-0.5 * 0.5);
 	});
 });
 
 describe("'n edge cases", () => {
 	it("'n(0) is treated as 1 repetition (clamped)", () => {
 		// 'n(n) requires n ≥ 1; 0 is clamped to 1.
-		const r = inst("note [0]'n(0)").evaluate({ cycleNumber: 0 });
+		const r = inst("note x [0]'n(0)").evaluate({ cycleNumber: 0 });
 		expect(r.ok).toBe(true);
 		if (r.ok) expect(r.events.length).toBeGreaterThanOrEqual(1);
 	});
 
 	it("'n(-1) — negative count treated as 1 repetition (clamped)", () => {
 		// 'n(n) requires n ≥ 1; negatives are clamped to 1.
-		const evs = eval0("note [0 2]'n(-1)");
+		const evs = eval0("note x [0 2]'n(-1)");
 		expect(evs).toHaveLength(2);
 	});
 
 	it("'n(1.5) rounds to 2 repetitions", () => {
 		// Math.round(1.5) = 2 in JS
-		expect(eval0("note [0]'n(1.5)")).toHaveLength(2);
+		expect(eval0("note x [0]'n(1.5)")).toHaveLength(2);
 	});
 });
 
@@ -1587,7 +1590,7 @@ describe("'wran edge cases", () => {
 	it('negative weight is clamped to 0 — only positive-weight element is selected', () => {
 		// [0?-1 1?1]'wran — weight for 0 clamped to 0, so only degree 1 ever fires
 		// Run 20 cycles to confirm degree 1 (D5=62) always wins
-		const i = inst("note [0?-1 1?1]'wran");
+		const i = inst("note x [0?-1 1?1]'wran");
 		for (let c = 0; c < 20; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			if (!r.ok) throw new Error(r.error);
@@ -1598,7 +1601,7 @@ describe("'wran edge cases", () => {
 
 	it('all-zero weights fall back to first element', () => {
 		// Evaluator fallback: if total weight = 0, return elements[0]
-		const i = inst("note [0?0 4?0]'wran");
+		const i = inst("note x [0?0 4?0]'wran");
 		for (let c = 0; c < 10; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			if (!r.ok) throw new Error(r.error);
@@ -1618,13 +1621,13 @@ describe("'wran edge cases", () => {
 // ---------------------------------------------------------------------------
 
 describe('timed lists — @ and : are absolute beat offsets from cycle start', () => {
-	it('note [4@1/2 7@1/4] — 2 events, sorted by beat (7@1/4 first, 4@1/2 second)', () => {
+	it('note x [4@1/2 7@1/4] — 2 events, sorted by beat (7@1/4 first, 4@1/2 second)', () => {
 		// sorted by beatOffset: 7@1/4 = C6=72 first, 4@1/2 = G5=67 second
-		expect(notes('note [4@1/2 7@1/4]')).toEqual([72, 67]);
+		expect(notes('note x [4@1/2 7@1/4]')).toEqual([72, 67]);
 	});
 
-	it('note [4@1/2 7@1/4] — events sorted by beatOffset (7 at 1/4 before 4 at 1/2)', () => {
-		const evs = eval0('note [4@1/2 7@1/4]');
+	it('note x [4@1/2 7@1/4] — events sorted by beatOffset (7 at 1/4 before 4 at 1/2)', () => {
+		const evs = eval0('note x [4@1/2 7@1/4]');
 		expect(evs[0].beatOffset).toBeCloseTo(0.25); // 7@1/4
 		expect(evs[1].beatOffset).toBeCloseTo(0.5); // 4@1/2
 		expect(evs[0].note).toBe(72); // degree 7 = C6
@@ -1632,35 +1635,35 @@ describe('timed lists — @ and : are absolute beat offsets from cycle start', (
 	});
 
 	it('timed list supports pitch context', () => {
-		// @key(g major) note [0@0 2@1/2] → G5=67, B5=71
-		expect(notes('@key(g major) note [0@0 2@1/2]')).toEqual([67, 71]);
+		// @key(g major) note x [0@0 2@1/2] → G5=67, B5=71
+		expect(notes('@key(g major) note x [0@0 2@1/2]')).toEqual([67, 71]);
 	});
 
-	it('note [0 2@1] — bare degree gets natural slot, @-timed degree gets override', () => {
-		const evs = eval0('note [0 2@1]');
+	it('note x [0 2@1] — bare degree gets natural slot, @-timed degree gets override', () => {
+		const evs = eval0('note x [0 2@1]');
 		expect(evs[0].beatOffset).toBeCloseTo(0); // 0 is in slot 0 of 2 = beat 0
 		expect(evs[1].beatOffset).toBeCloseTo(1.0); // 2@1 → absolute beat 1
 	});
 
-	it('note [0 4 7@1/2] — two bare degrees then one timed', () => {
-		const evs = eval0('note [0 4 7@1/2]');
+	it('note x [0 4 7@1/2] — two bare degrees then one timed', () => {
+		const evs = eval0('note x [0 4 7@1/2]');
 		expect(evs[0].beatOffset).toBeCloseTo(0); // slot 0 of 3
 		expect(evs[1].beatOffset).toBeCloseTo(1 / 3); // slot 1 of 3
 		expect(evs[2].beatOffset).toBeCloseTo(0.5); // 7@1/2 → absolute 0.5
 	});
 
-	it('note [0 2@1] — notes are correct', () => {
-		expect(notes('note [0 2@1]')).toEqual([60, 64]);
+	it('note x [0 2@1] — notes are correct', () => {
+		expect(notes('note x [0 2@1]')).toEqual([60, 64]);
 	});
 
-	it('note [0 2@1.5] — float time is honoured', () => {
-		const evs = eval0('note [0 2@1.5]');
+	it('note x [0 2@1.5] — float time is honoured', () => {
+		const evs = eval0('note x [0 2@1.5]');
 		expect(evs[0].beatOffset).toBeCloseTo(0);
 		expect(evs[1].beatOffset).toBeCloseTo(1.5);
 	});
 
-	it('note [0@0.0 4@0.5] — float times on all elements', () => {
-		const evs = eval0('note [0@0.0 4@0.5]');
+	it('note x [0@0.0 4@0.5] — float times on all elements', () => {
+		const evs = eval0('note x [0@0.0 4@0.5]');
 		expect(evs[0].beatOffset).toBeCloseTo(0);
 		expect(evs[1].beatOffset).toBeCloseTo(0.5);
 	});
@@ -1668,7 +1671,7 @@ describe('timed lists — @ and : are absolute beat offsets from cycle start', (
 	it('events are sorted by beatOffset — out-of-source-order @ does not produce negative gaps', () => {
 		// source order: 0 (natural slot 0), 1 (natural slot 1/3), 4@0.01 (override 0.01)
 		// sorted order: 0 at 0, 4 at 0.01, 1 at 0.333
-		const evs = eval0('note [0 1 4@0.01]');
+		const evs = eval0('note x [0 1 4@0.01]');
 		for (let i = 1; i < evs.length; i++) {
 			expect(evs[i].beatOffset).toBeGreaterThanOrEqual(evs[i - 1].beatOffset);
 		}
@@ -1687,32 +1690,32 @@ describe('timed lists — @ and : are absolute beat offsets from cycle start', (
 // ---------------------------------------------------------------------------
 
 describe('synthdef selection — note(\\moog) / note(\\sine)', () => {
-	it('note(\\moog) [0 2 4] — produces 3 note events', () => {
-		expect(eval0('note(\\moog) [0 2 4]')).toHaveLength(3);
+	it('note(\\moog) lead [0 2 4] — produces 3 note events', () => {
+		expect(eval0('note(\\moog) lead [0 2 4]')).toHaveLength(3);
 	});
 
-	it('note(\\moog) [0 2 4] — notes are correct (pitch chain unaffected by synthdef)', () => {
-		expect(notes('note(\\moog) [0 2 4]')).toEqual([60, 64, 67]);
+	it('note(\\moog) lead [0 2 4] — notes are correct (pitch chain unaffected by synthdef)', () => {
+		expect(notes('note(\\moog) lead [0 2 4]')).toEqual([60, 64, 67]);
 	});
 
 	it('note(\\moog) — every note event carries synthdef: "moog"', () => {
-		for (const e of eval0('note(\\moog) [0 2 4]')) {
+		for (const e of eval0('note(\\moog) lead [0 2 4]')) {
 			expect(e.synthdef).toBe('moog');
 		}
 	});
 
-	it('note(\\sine) [0 1 2] — produces 3 note events', () => {
-		expect(eval0('note(\\sine) [0 1 2]')).toHaveLength(3);
+	it('note(\\sine) lead [0 1 2] — produces 3 note events', () => {
+		expect(eval0('note(\\sine) lead [0 1 2]')).toHaveLength(3);
 	});
 
 	it('note(\\sine) — every note event carries synthdef: "sine"', () => {
-		for (const e of eval0('note(\\sine) [0 1 2]')) {
+		for (const e of eval0('note(\\sine) lead [0 1 2]')) {
 			expect(e.synthdef).toBe('sine');
 		}
 	});
 
 	it('note without synthdef arg — events have no synthdef field', () => {
-		for (const e of eval0('note [0 2 4]')) {
+		for (const e of eval0('note x [0 2 4]')) {
 			expect(e.synthdef).toBeUndefined();
 		}
 	});
@@ -1727,28 +1730,28 @@ describe('synthdef selection — note(\\moog) / note(\\sine)', () => {
 // ---------------------------------------------------------------------------
 
 describe('inline repetition — !n', () => {
-	it('note [1!4] produces 4 events at the same note', () => {
-		const ns = notes('note [1!4]');
+	it('note x [1!4] produces 4 events at the same note', () => {
+		const ns = notes('note x [1!4]');
 		expect(ns).toHaveLength(4);
 		expect(new Set(ns).size).toBe(1); // all identical
 	});
 
-	it('note [1!2 3!3] produces 5 events (2+3)', () => {
-		const ns = notes('note [1!2 3!3]');
+	it('note x [1!2 3!3] produces 5 events (2+3)', () => {
+		const ns = notes('note x [1!2 3!3]');
 		expect(ns).toHaveLength(5);
 		// first two are degree 1, last three are degree 3
-		const d1 = notes('note [1]')[0];
-		const d3 = notes('note [3]')[0];
+		const d1 = notes('note x [1]')[0];
+		const d3 = notes('note x [3]')[0];
 		expect(ns.slice(0, 2).every((n) => n === d1)).toBe(true);
 		expect(ns.slice(2).every((n) => n === d3)).toBe(true);
 	});
 
-	it('note [1!1] is identical to note [1]', () => {
-		expect(notes('note [1!1]')).toEqual(notes('note [1]'));
+	it('note x [1!1] is identical to note [1]', () => {
+		expect(notes('note x [1!1]')).toEqual(notes('note x [1]'));
 	});
 
 	it('events are evenly spaced within a 1!4 pattern', () => {
-		const offs = offsets('note [1!4]');
+		const offs = offsets('note x [1!4]');
 		expect(offs).toHaveLength(4);
 		// Each slot is 1/4 of a cycle in beats (cycle = 1 beat in the evaluator model)
 		expect(offs[0]).toBeCloseTo(0);
@@ -1758,7 +1761,7 @@ describe('inline repetition — !n', () => {
 	});
 
 	it('stochastic element 0rand7!4 — all four copies share the same drawn value per cycle', () => {
-		const ns = notes('note [0rand7!4]');
+		const ns = notes('note x [0rand7!4]');
 		expect(ns).toHaveLength(4);
 		// eager(1): value drawn once per cycle — all four copies identical
 		expect(new Set(ns).size).toBe(1);
@@ -1771,32 +1774,36 @@ describe('inline repetition — !n', () => {
 
 describe('block comments', () => {
 	it('/* comment */ before note is ignored', () => {
-		expect(notes('/* ignored */ note [0 2 4]')).toEqual(notes('note [0 2 4]'));
+		expect(notes('/* ignored */ note x [0 2 4]')).toEqual(notes('note x [0 2 4]'));
 	});
 
 	it('block comment between two elements is ignored', () => {
-		expect(notes('note [0 /* mid */ 2 4]')).toEqual(notes('note [0 2 4]'));
+		expect(notes('note x [0 /* mid */ 2 4]')).toEqual(notes('note x [0 2 4]'));
 	});
 });
 
 describe('accidentals in non-default pitch contexts', () => {
-	it('@root(7) note [2#] — sharp applied after root shift (G major, degree 2 = B5 = 71, +1 = 72)', () => {
+	it('@root(7) note x [2#] — sharp applied after root shift (G major, degree 2 = B5 = 71, +1 = 72)', () => {
 		// G5=67, G major scale, degree 2 = B5 = 71, sharp → 72 = C6
-		expect(notes('@root(7) note [2#]')[0]).toBe(notes('@root(7) note [2]')[0] + 1);
+		expect(notes('@root(7) note x [2#]')[0]).toBe(notes('@root(7) note x [2]')[0] + 1);
 	});
 
-	it('@scale(\\minor) note [4b] — flat applied in minor context (degree 4 = G5 = 67, -1 = 66)', () => {
+	it('@scale(\\minor) note x [4b] — flat applied in minor context (degree 4 = G5 = 67, -1 = 66)', () => {
 		// C minor, degree 4 = G5 = 67 (minor has same perfect 5th), flat → 66 = F#5
-		expect(notes('@scale(\\minor) note [4b]')[0]).toBe(notes('@scale(\\minor) note [4]')[0] - 1);
+		expect(notes('@scale(\\minor) note x [4b]')[0]).toBe(
+			notes('@scale(\\minor) note x [4]')[0] - 1
+		);
 	});
 
-	it('@key(g major 4) note [3#] — accidental in compound key context', () => {
+	it('@key(g major 4) note x [3#] — accidental in compound key context', () => {
 		// G major octave 4: root = G4 = 55. degree 3 in major = 5 semitones → C5 = 60. Sharp → 61.
-		expect(notes('@key(g major 4) note [3#]')[0]).toBe(notes('@key(g major 4) note [3]')[0] + 1);
+		expect(notes('@key(g major 4) note x [3#]')[0]).toBe(
+			notes('@key(g major 4) note x [3]')[0] + 1
+		);
 	});
 
-	it('@root(7) note [2bb] — double flat: two semitones below', () => {
-		expect(notes('@root(7) note [2bb]')[0]).toBe(notes('@root(7) note [2]')[0] - 2);
+	it('@root(7) note x [2bb] — double flat: two semitones below', () => {
+		expect(notes('@root(7) note x [2bb]')[0]).toBe(notes('@root(7) note x [2]')[0] - 2);
 	});
 });
 
@@ -1805,49 +1812,49 @@ describe('accidentals in non-default pitch contexts', () => {
 // ---------------------------------------------------------------------------
 
 describe('rests (_) — structural slot count', () => {
-	it('note [0 2 _ 4] emits 4 events, 3rd is type:rest', () => {
-		const evs = eval0('note [0 2 _ 4]');
+	it('note x [0 2 _ 4] emits 4 events, 3rd is type:rest', () => {
+		const evs = eval0('note x [0 2 _ 4]');
 		expect(evs).toHaveLength(4);
 		expect(evs[2].type).toBe('rest');
 	});
 
 	it('rest event has no note pitch (note is -1 or absent)', () => {
-		const evs = eval0('note [0 2 _ 4]');
+		const evs = eval0('note x [0 2 _ 4]');
 		// note is -1 for rests — no synth should be spawned
 		expect(evs[2].note).toBe(-1);
 	});
 
 	it('rest occupies the correct beat offset (uniformly spaced, 1/4 cycle each)', () => {
-		const evs = eval0('note [0 2 _ 4]');
+		const evs = eval0('note x [0 2 _ 4]');
 		expect(evs[2].beatOffset).toBeCloseTo(0.5);
 	});
 
 	it('rest at start: note [_ 2 4] — first event is rest', () => {
-		const evs = eval0('note [_ 2 4]');
+		const evs = eval0('note x [_ 2 4]');
 		expect(evs[0].type).toBe('rest');
-		expect(evs[1].note).toBe(notes('note [2]')[0]);
+		expect(evs[1].note).toBe(notes('note x [2]')[0]);
 	});
 
 	it('rest at end: note [0 2 _] — last event is rest', () => {
-		const evs = eval0('note [0 2 _]');
+		const evs = eval0('note x [0 2 _]');
 		expect(evs[2].type).toBe('rest');
 	});
 
 	it('all rests: note [_ _ _] — 3 events all type:rest', () => {
-		const evs = eval0('note [_ _ _]');
+		const evs = eval0('note x [_ _ _]');
 		expect(evs).toHaveLength(3);
 		expect(evs.every((e) => e.type === 'rest')).toBe(true);
 	});
 
 	it('note events are type:note (or undefined) — not type:rest', () => {
-		const evs = eval0('note [0 2 4]');
+		const evs = eval0('note x [0 2 4]');
 		for (const e of evs) {
 			expect(e.type).not.toBe('rest');
 		}
 	});
 
 	it('rest duration spans its slot (same as a note slot)', () => {
-		const evs = eval0('note [0 2 _ 4]');
+		const evs = eval0('note x [0 2 _ 4]');
 		// 4 elements → slot = 0.25; rest duration should equal the slot
 		expect(evs[2].duration).toBeCloseTo(0.25);
 	});
@@ -1859,14 +1866,14 @@ describe('rests (_) — structural slot count', () => {
 
 describe('createInstance — error message content', () => {
 	it('parse error message starts with "Parse error:"', () => {
-		const result = createInstance('note [0 1 2'); // unclosed bracket
+		const result = createInstance('note x [0 1 2'); // unclosed bracket
 		if (result.ok) throw new Error('expected error');
 		expect(result.error).toMatch(/^Parse error:/);
 	});
 
 	it('lex error message starts with "Lex error:"', () => {
 		// Bare backslash is an unrecognised character → lex error
-		const result = createInstance('note [0 \\1]');
+		const result = createInstance('note x [0 \\1]');
 		if (result.ok) throw new Error('expected error');
 		expect(result.error).toMatch(/^(Lex error:|Parse error:)/);
 	});
@@ -1884,7 +1891,7 @@ describe('createInstance — error message content', () => {
 	});
 
 	it('parse error message includes some description of the problem', () => {
-		const result = createInstance('note [0 1 2');
+		const result = createInstance('note x [0 1 2');
 		if (result.ok) throw new Error('expected error');
 		// The error string must be non-trivially descriptive (not just "Parse error:")
 		expect(result.error.length).toBeGreaterThan('Parse error:'.length + 2);
@@ -1912,33 +1919,138 @@ describe('createInstance — error message content', () => {
 
 describe('multiple patterns — all patterns produce events', () => {
 	it('two plain patterns both emit events in the same cycle', () => {
-		// note(\kick) [0 1 2 3 5] has 5 elements; note [-2 0 2] has 3 elements.
+		// note(\kick) a [0 1 2 3 5] has 5 elements; note b [-2 0 2] has 3 elements.
 		// All 8 events should be present.
-		const events = eval0('note(\\kick) [0 1 2 3 5]\n\nnote [-2 0 2]');
+		const events = eval0('note(\\kick) a [0 1 2 3 5]\n\nnote b [-2 0 2]');
 		expect(events).toHaveLength(8);
 	});
 
 	it('first pattern events use the given synthdef', () => {
-		const events = eval0('note(\\kick) [0 1 2 3 5]\n\nnote [-2 0 2]');
+		const events = eval0('note(\\kick) a [0 1 2 3 5]\n\nnote b [-2 0 2]');
 		const kickEvents = events.filter((e) => e.synthdef === 'kick');
 		expect(kickEvents).toHaveLength(5);
 	});
 
 	it('second pattern events have no synthdef', () => {
-		const events = eval0('note(\\kick) [0 1 2 3 5]\n\nnote [-2 0 2]');
+		const events = eval0('note(\\kick) a [0 1 2 3 5]\n\nnote b [-2 0 2]');
 		const plainEvents = events.filter((e) => e.synthdef === undefined);
 		expect(plainEvents).toHaveLength(3);
 	});
 
 	it('commenting out the first pattern leaves only the second', () => {
-		const events = eval0('// note(\\kick) [0 1 2 3 5]\n\nnote [-2 0 2]');
+		const events = eval0('// note(\\kick) a [0 1 2 3 5]\n\nnote b [-2 0 2]');
 		expect(events).toHaveLength(3);
 	});
 
 	it('second pattern is independent when first is absent', () => {
-		const eventsSecondOnly = eval0('note [-2 0 2]');
-		const eventsBoth = eval0('note(\\kick) [0 1 2 3 5]\n\nnote [-2 0 2]');
+		const eventsSecondOnly = eval0('note x [-2 0 2]');
+		const eventsBoth = eval0('note(\\kick) a [0 1 2 3 5]\n\nnote b [-2 0 2]');
 		const secondInBoth = eventsBoth.filter((e) => e.synthdef === undefined);
 		expect(secondInBoth.map((e) => e.note)).toEqual(eventsSecondOnly.map((e) => e.note));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Generator naming (issue #2)
+// ---------------------------------------------------------------------------
+
+describe('generator naming — static errors', () => {
+	it('duplicate names in one evaluation are a static error', () => {
+		const i = createInstance('note lead [0 2 4]\nnote lead [0 4 7]');
+		expect(i.ok).toBe(false);
+		if (!i.ok) expect(i.error).toMatch(/duplicate.*lead|lead.*duplicate/i);
+	});
+
+	it('two different names in one evaluation are fine', () => {
+		const i = createInstance('note lead [0 2 4]\nnote bass [0 1 2]');
+		expect(i.ok).toBe(true);
+	});
+
+	it('dangling derived reference is a static error', () => {
+		// "perc" references "drums" which is not present
+		const i = createInstance('note perc:drums [0 2 4]');
+		expect(i.ok).toBe(false);
+		if (!i.ok) expect(i.error).toMatch(/drums|dangling|parent/i);
+	});
+
+	it('derived reference with present parent is fine', () => {
+		const i = createInstance('note drums [0 1 2]\nnote perc:drums [0 2 4]');
+		expect(i.ok).toBe(true);
+	});
+
+	it('derived generator with no body (inherits parent) is fine', () => {
+		const i = createInstance('note lead [0 2 4]\nnote harm:lead');
+		expect(i.ok).toBe(true);
+	});
+});
+
+describe('generator naming — reinit()', () => {
+	it('instance has a reinit method', () => {
+		const i = createInstance('note lead [0 2 4]');
+		expect(i.ok).toBe(true);
+		if (i.ok) expect(typeof i.reinit).toBe('function');
+	});
+
+	it('reinit with valid new source returns ok:true', () => {
+		const i = createInstance('note lead [0 2 4]');
+		if (!i.ok) throw new Error(i.error);
+		const result = i.reinit('note lead [0 4 7]');
+		expect(result.ok).toBe(true);
+	});
+
+	it('reinit with invalid source returns ok:false', () => {
+		const i = createInstance('note lead [0 2 4]');
+		if (!i.ok) throw new Error(i.error);
+		const result = i.reinit('note lead [0 1 2'); // unclosed bracket
+		expect(result.ok).toBe(false);
+	});
+
+	it('reinit with duplicate name returns ok:false', () => {
+		const i = createInstance('note lead [0 2 4]');
+		if (!i.ok) throw new Error(i.error);
+		const result = i.reinit('note lead [0 2 4]\nnote lead [0 1]');
+		expect(result.ok).toBe(false);
+	});
+
+	it('after reinit, evaluate uses new pattern', () => {
+		const i = createInstance('note lead [0]');
+		if (!i.ok) throw new Error(i.error);
+		const before = i.evaluate({ cycleNumber: 0 });
+		if (!before.ok) throw new Error(before.error);
+		expect(before.events[0].note).toBe(60); // degree 0 = C5
+
+		i.reinit('note lead [4]'); // degree 4 = G5
+		const after = i.evaluate({ cycleNumber: 1 });
+		if (!after.ok) throw new Error(after.error);
+		expect(after.events[0].note).toBe(67); // G5
+	});
+
+	it('reinit preserves runner state for unchanged named generators (lock survives reinit)', () => {
+		// lead uses 'lock — the random value should be the same after reinit
+		// We reinit with the same source, so the runner state is reused.
+		const i = createInstance("note lead [0rand7]'lock");
+		if (!i.ok) throw new Error(i.error);
+		const r1 = i.evaluate({ cycleNumber: 0 });
+		if (!r1.ok) throw new Error(r1.error);
+		const noteBefore = r1.events[0].note;
+
+		i.reinit("note lead [0rand7]'lock");
+		const r2 = i.evaluate({ cycleNumber: 1 });
+		if (!r2.ok) throw new Error(r2.error);
+		// Same locked value should be used
+		expect(r2.events[0].note).toBe(noteBefore);
+	});
+});
+
+describe('derived generator — produces parallel events', () => {
+	it('note over:lead + 2 produces 4 events alongside lead', () => {
+		const i = inst('note lead [0 1 2 3]\nnote over:lead + 2');
+		const r = i.evaluate({ cycleNumber: 0 });
+		if (!r.ok) throw new Error(r.error);
+		// lead: degrees 0,1,2,3 → C5,D5,E5,F5 = 60,62,64,65
+		// over: same degrees + 2 → 2,3,4,5 → E5,F5,G5,A5 = 64,65,67,69
+		expect(r.events).toHaveLength(8);
+		const sorted = r.events.map((e) => e.note).sort((a, b) => a - b);
+		expect(sorted).toEqual([60, 62, 64, 64, 65, 65, 67, 69]);
 	});
 });

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -92,10 +92,14 @@ export type EvalCycleResult =
 	| { ok: true; events: ScheduledEvent[]; done: boolean }
 	| { ok: false; error: string };
 
+export type ReinitResult = { ok: true } | { ok: false; error: string };
+
 export type EvalInstance =
 	| {
 			ok: true;
 			evaluate: (ctx: CycleContext) => EvalCycleResult;
+			/** Re-compile from new source, preserving runner state for unchanged named generators. */
+			reinit: (newSource: string) => ReinitResult;
 	  }
 	| { ok: false; error: string };
 
@@ -971,6 +975,8 @@ function compileTransposition(patternNode: CstNode): CompiledTransposition {
 type TraversalMode = 'seq' | 'shuf' | 'pick' | 'wran';
 
 type CompiledPattern = {
+	name: string; // generator name (mandatory since issue #2)
+	parentName: string | null; // parent name for derived (child:parent) generators; null = plain
 	elements: CompiledElement[];
 	listMode: EagerMode; // mode from list-level modifiers (inherited by elements)
 	traversal: TraversalMode;
@@ -1009,7 +1015,10 @@ function collectPatternModifiers(patternNode: CstNode): CstNode[] {
 	return [...seqMods, ...directMods, ...contMods];
 }
 
-function compilePattern(patternNode: CstNode): CompiledPattern | string {
+function compilePattern(
+	patternNode: CstNode,
+	parentPattern?: CompiledPattern
+): CompiledPattern | string {
 	const seqNode = (
 		(patternNode.children.sequenceExpr ?? patternNode.children.sequenceGenerator) as
 			| CstNode[]
@@ -1018,10 +1027,10 @@ function compilePattern(patternNode: CstNode): CompiledPattern | string {
 	const relNode = ((patternNode.children.relTimedList as CstNode[]) ?? [])[0];
 
 	const bodyNode = seqNode ?? relNode;
-	if (!bodyNode) return 'pattern has no sequence body';
+	if (!bodyNode && !parentPattern) return 'pattern has no sequence body';
 
 	// List-level modifiers (on the [...] itself)
-	const listMods = (bodyNode.children.modifierSuffix as CstNode[]) ?? [];
+	const listMods = bodyNode ? ((bodyNode.children.modifierSuffix as CstNode[]) ?? []) : [];
 	const listMode = extractEagerMode(listMods) ?? DEFAULT_MODE;
 
 	// Traversal mode
@@ -1046,6 +1055,22 @@ function compilePattern(patternNode: CstNode): CompiledPattern | string {
 			const ce = compileTimedElement(elem, listMode);
 			if (ce) compiled.push(ce);
 		}
+	} else if (parentPattern) {
+		// Derived generator with no body — inherit parent's elements (deep-copy runners)
+		for (const el of parentPattern.elements) {
+			if (el.kind === 'scalar') {
+				compiled.push({
+					kind: 'scalar',
+					runner: makeRunner(el.runner.poll, el.runner.mode),
+					accidentalOffset: el.accidentalOffset,
+					weight: makeRunner(el.weight.poll, el.weight.mode),
+					...(el.beatOverride !== undefined && { beatOverride: el.beatOverride })
+				});
+			} else {
+				compiled.push(el);
+			}
+		}
+		traversal = parentPattern.traversal;
 	}
 
 	if (compiled.length === 0) return 'pattern sequence is empty';
@@ -1102,7 +1127,15 @@ function compilePattern(patternNode: CstNode): CompiledPattern | string {
 		: null;
 	const synthdef = synthdefTok ? synthdefTok.image.slice(1) : null;
 
+	// Generator name and optional parent name (child:parent syntax)
+	const genNameNode = ((patternNode.children.generatorName as CstNode[]) ?? [])[0];
+	const genNameToks = genNameNode ? ((genNameNode.children.Identifier as IToken[]) ?? []) : [];
+	const name = genNameToks[0]?.image ?? '';
+	const parentName = genNameToks[1]?.image ?? null;
+
 	return {
+		name,
+		parentName,
 		elements: compiled,
 		listMode,
 		traversal,
@@ -1457,7 +1490,16 @@ function resolveDecoratorContext(
 // createInstance — public entry point
 // ---------------------------------------------------------------------------
 
-export function createInstance(source: string): EvalInstance {
+type PatternEntry =
+	| { kind: 'plain'; compiled: CompiledPattern }
+	| { kind: 'decorated'; compiled: CompiledPattern; decoratorLayers: CstNode[][] };
+
+type CompileResult =
+	| { ok: true; setNodes: CstNode[]; patternEntries: PatternEntry[] }
+	| { ok: false; error: string };
+
+/** Parse and compile a source string into setNodes and patternEntries. */
+function compileSource(source: string): CompileResult {
 	const { tokens, errors: lexErrors } = FluxLexer.tokenize(source);
 	if (lexErrors.length > 0) {
 		return { ok: false, error: `Lex error: ${lexErrors[0].message}` };
@@ -1469,46 +1511,55 @@ export function createInstance(source: string): EvalInstance {
 		return { ok: false, error: `Parse error: ${parser.errors[0].message}` };
 	}
 
-	// ---------------------------------------------------------------------------
-	// Compile phase: find all statements, partition into sets and patterns.
-	// The scale context is built lazily at evaluate() time from set nodes and
-	// decorator blocks so that stochastic decorator args respect cycle semantics.
-	// ---------------------------------------------------------------------------
-
 	const statements = (cst.children.statement ?? []) as CstNode[];
-
-	type PatternEntry =
-		| { kind: 'plain'; compiled: CompiledPattern }
-		| { kind: 'decorated'; compiled: CompiledPattern; decoratorLayers: CstNode[][] };
-
 	const setNodes: CstNode[] = [];
 	const patternEntries: PatternEntry[] = [];
+
+	// Collect plain (non-decorator) pattern statement nodes for two-pass processing.
+	// Decorated blocks are pre-compiled by compileDecoratorBlock and don't support
+	// child:parent derivation (they're processed in a single pass below).
+	const plainPatternNodes: CstNode[] = [];
+	const compiledByName = new Map<string, CompiledPattern>();
 
 	for (const stmt of statements) {
 		const patternNodes = stmt.children.patternStatement as CstNode[] | undefined;
 		if (patternNodes?.length) {
-			const compiled = compilePattern(patternNodes[0]);
-			if (typeof compiled !== 'string') {
-				patternEntries.push({ kind: 'plain', compiled });
-			}
+			plainPatternNodes.push(patternNodes[0]);
 			continue;
 		}
-
 		const setNodes2 = stmt.children.setStatement as CstNode[] | undefined;
 		if (setNodes2?.length) {
 			setNodes.push(setNodes2[0]);
 			continue;
 		}
-
 		const decBlockNodes = stmt.children.decoratorBlock as CstNode[] | undefined;
 		if (decBlockNodes?.length) {
-			// Compile patterns eagerly (runners keep state across cycles).
-			// Decorator context is resolved lazily per cycle.
-			const compiled = compileDecoratorBlock(decBlockNodes[0], []);
-			for (const { compiled: cl, decoratorLayers } of compiled) {
+			const innerCompiled = compileDecoratorBlock(decBlockNodes[0], []);
+			for (const { compiled: cl, decoratorLayers } of innerCompiled) {
+				if (cl.name) compiledByName.set(cl.name, cl);
 				patternEntries.push({ kind: 'decorated', compiled: cl, decoratorLayers });
 			}
 			continue;
+		}
+	}
+
+	// Pass 1: compile plain non-derived patterns (no child:parent) and register by name.
+	// Pass 2: compile derived patterns, resolving parents from the map built in pass 1.
+	for (let pass = 1; pass <= 2; pass++) {
+		for (const node of plainPatternNodes) {
+			const genNameNode = ((node.children.generatorName as CstNode[]) ?? [])[0];
+			const genNameToks = genNameNode ? ((genNameNode.children.Identifier as IToken[]) ?? []) : [];
+			const isDerived = genNameToks.length >= 2;
+			if (pass === 1 && isDerived) continue;
+			if (pass === 2 && !isDerived) continue;
+
+			const parentName = isDerived ? (genNameToks[1]?.image ?? null) : null;
+			const parent = parentName ? compiledByName.get(parentName) : undefined;
+			const compiled = compilePattern(node, parent);
+			if (typeof compiled !== 'string') {
+				compiledByName.set(compiled.name, compiled);
+				patternEntries.push({ kind: 'plain', compiled });
+			}
 		}
 	}
 
@@ -1516,42 +1567,156 @@ export function createInstance(source: string): EvalInstance {
 		return { ok: false, error: 'No pattern statement found' };
 	}
 
+	return { ok: true, setNodes, patternEntries };
+}
+
+/**
+ * Validate generator names in a list of pattern entries.
+ * Returns an error string if:
+ *   - Two patterns share the same name (duplicate name static error)
+ *   - A derived generator references a parent name not present in the same evaluation
+ */
+function validateNames(patternEntries: PatternEntry[]): string | null {
+	const names = new Set<string>();
+	// Collect all names first (detect duplicates)
+	for (const entry of patternEntries) {
+		const { name } = entry.compiled;
+		if (!name) continue;
+		if (names.has(name)) {
+			return `Duplicate generator name: "${name}"`;
+		}
+		names.add(name);
+	}
+	// Check derived refs
+	for (const entry of patternEntries) {
+		const { parentName } = entry.compiled;
+		if (parentName && !names.has(parentName)) {
+			return `Dangling derived reference: parent generator "${parentName}" not found in this evaluation`;
+		}
+	}
+	return null;
+}
+
+/**
+ * Transfer runner state from old pattern entries to new ones where names match.
+ * For each CompiledPattern in newEntries whose name matches one in oldEntries,
+ * copy the runner state arrays so that locked values survive reinit.
+ */
+function transferRunnerState(oldEntries: PatternEntry[], newEntries: PatternEntry[]): void {
+	const oldByName = new Map<string, CompiledPattern>();
+	for (const e of oldEntries) {
+		if (e.compiled.name) oldByName.set(e.compiled.name, e.compiled);
+	}
+	for (const e of newEntries) {
+		const { name } = e.compiled;
+		if (!name) continue;
+		const old = oldByName.get(name);
+		if (!old) continue;
+		// Transfer runner state for matching runners by position.
+		// Runners are positional within the compiled elements array.
+		// We only transfer if element counts match — if the pattern changed
+		// structurally, runners are rebuilt fresh.
+		if (old.elements.length === e.compiled.elements.length) {
+			for (let i = 0; i < old.elements.length; i++) {
+				const oldEl = old.elements[i];
+				const newEl = e.compiled.elements[i];
+				if (oldEl.kind === 'scalar' && newEl.kind === 'scalar') {
+					// Transfer lock state: if old runner has a cached value, share it
+					if (oldEl.runner.hasValue) {
+						newEl.runner.hasValue = oldEl.runner.hasValue;
+						newEl.runner.cachedValue = oldEl.runner.cachedValue;
+						newEl.runner.lastSampledCycle = oldEl.runner.lastSampledCycle;
+					}
+				}
+			}
+		}
+		// Transfer pattern-level runner state (stut, maybe, legato, offset)
+		for (const key of ['stutRunner', 'maybeRunner', 'legatoRunner', 'offsetRunner'] as const) {
+			const oldR = old[key];
+			const newR = e.compiled[key];
+			if (oldR && newR && oldR.hasValue) {
+				newR.hasValue = oldR.hasValue;
+				newR.cachedValue = oldR.cachedValue;
+				newR.lastSampledCycle = oldR.lastSampledCycle;
+			}
+		}
+	}
+}
+
+function makeEvaluator(
+	setNodes: CstNode[],
+	patternEntries: PatternEntry[]
+): (ctx: CycleContext) => EvalCycleResult {
+	return function evaluate(ctx: CycleContext): EvalCycleResult {
+		const { cycleNumber } = ctx;
+
+		// Build the global ScaleContext from set statements
+		let globalCtx: ScaleContext = { ...DEFAULT_SCALE_CONTEXT };
+		for (const setNode of setNodes) {
+			globalCtx = applySetStatement(setNode, globalCtx, cycleNumber);
+		}
+
+		// Evaluate all patterns and collect their events
+		const allEvents: ScheduledEvent[] = [];
+		let anyDone = false;
+		let evaluated = false;
+
+		for (const entry of patternEntries) {
+			const compiled = entry.compiled;
+			const scaleCtx =
+				entry.kind === 'decorated'
+					? resolveDecoratorContext(entry.decoratorLayers, globalCtx, cycleNumber)
+					: globalCtx;
+
+			const { elements } = compiled;
+			if (elements.length === 0) continue;
+
+			const { events, done } = evaluateCompiledPattern(compiled, scaleCtx, cycleNumber);
+			allEvents.push(...events);
+			if (done) anyDone = true;
+			evaluated = true;
+		}
+
+		if (!evaluated) {
+			return { ok: false, error: 'No pattern found in evaluate' };
+		}
+		return { ok: true, events: allEvents, done: anyDone };
+	};
+}
+
+export function createInstance(source: string): EvalInstance {
+	const compiled = compileSource(source);
+	if (!compiled.ok) return compiled;
+
+	const nameError = validateNames(compiled.patternEntries);
+	if (nameError) return { ok: false, error: nameError };
+
+	// Mutable state: current set nodes and pattern entries (updated by reinit)
+	let currentSetNodes = compiled.setNodes;
+	let currentPatternEntries = compiled.patternEntries;
+
 	return {
 		ok: true,
-		evaluate(ctx: CycleContext): EvalCycleResult {
-			const { cycleNumber } = ctx;
+		evaluate: makeEvaluator(currentSetNodes, currentPatternEntries),
+		reinit(newSource: string): ReinitResult {
+			const newCompiled = compileSource(newSource);
+			if (!newCompiled.ok) return { ok: false, error: newCompiled.error };
 
-			// Build the global ScaleContext from set statements
-			let globalCtx: ScaleContext = { ...DEFAULT_SCALE_CONTEXT };
-			for (const setNode of setNodes) {
-				globalCtx = applySetStatement(setNode, globalCtx, cycleNumber);
-			}
+			const newNameError = validateNames(newCompiled.patternEntries);
+			if (newNameError) return { ok: false, error: newNameError };
 
-			// Evaluate all patterns and collect their events
-			const allEvents: ScheduledEvent[] = [];
-			let anyDone = false;
-			let evaluated = false;
+			// Transfer runner state from old patterns to new ones with matching names
+			transferRunnerState(currentPatternEntries, newCompiled.patternEntries);
 
-			for (const entry of patternEntries) {
-				const compiled = entry.compiled;
-				const scaleCtx =
-					entry.kind === 'decorated'
-						? resolveDecoratorContext(entry.decoratorLayers, globalCtx, cycleNumber)
-						: globalCtx;
+			// Swap in new state
+			currentSetNodes = newCompiled.setNodes;
+			currentPatternEntries = newCompiled.patternEntries;
 
-				const { elements } = compiled;
-				if (elements.length === 0) continue;
+			// Rebind the evaluate function to use the new entries
+			const self = this as Extract<EvalInstance, { ok: true }>;
+			self.evaluate = makeEvaluator(currentSetNodes, currentPatternEntries);
 
-				const { events, done } = evaluateCompiledPattern(compiled, scaleCtx, cycleNumber);
-				allEvents.push(...events);
-				if (done) anyDone = true;
-				evaluated = true;
-			}
-
-			if (!evaluated) {
-				return { ok: false, error: 'No pattern found in evaluate' };
-			}
-			return { ok: true, events: allEvents, done: anyDone };
+			return { ok: true };
 		}
 	};
 }

--- a/src/lib/lang/lexer.ts
+++ b/src/lib/lang/lexer.ts
@@ -632,6 +632,7 @@ export const allTokens = [
 	Plus,
 	Minus,
 	Slash,
+	Colon,
 	Bang,
 	// Literals — Float before Integer
 	Float,

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -11,14 +11,15 @@ function parse(src: string) {
 }
 
 describe('patternStatement — note', () => {
-	it('parses note with a sequence body', () => {
-		const { parseErrors } = parse('note [0 2 4]');
+	it('parses note with a name and sequence body', () => {
+		const { parseErrors } = parse('note lead [0 2 4]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('errors on note without a sequence body', () => {
-		const { parseErrors } = parse("note 'stut");
-		expect(parseErrors.length).toBeGreaterThan(0);
+	it('accepts note with name and no body (body-required check is in the evaluator)', () => {
+		// Parser allows it; evaluator rejects non-derived patterns with no body.
+		const { parseErrors } = parse("note lead 'stut");
+		expect(parseErrors).toHaveLength(0);
 	});
 
 	it('errors on bare note keyword', () => {
@@ -26,25 +27,25 @@ describe('patternStatement — note', () => {
 		expect(parseErrors.length).toBeGreaterThan(0);
 	});
 
-	it('parses negative degrees: note [-1 0 2]', () => {
-		const { parseErrors } = parse('note [-1 0 2]');
+	it('parses negative degrees: note lead [-1 0 2]', () => {
+		const { parseErrors } = parse('note lead [-1 0 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses mixed positive and negative degrees: note [-3 -1 0 2 4]', () => {
-		const { parseErrors } = parse('note [-3 -1 0 2 4]');
+	it('parses mixed positive and negative degrees: note lead [-3 -1 0 2 4]', () => {
+		const { parseErrors } = parse('note lead [-3 -1 0 2 4]');
 		expect(parseErrors).toHaveLength(0);
 	});
 });
 
 describe('patternStatement — mono', () => {
-	it('parses mono with a sequence body', () => {
-		const { parseErrors } = parse('mono [0 1 2 3]');
+	it('parses mono with a name and sequence body', () => {
+		const { parseErrors } = parse('mono bass [0 1 2 3]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses mono with synthdef symbol arg', () => {
-		const { parseErrors } = parse('mono(\\moog) [0 1 2]');
+	it('parses mono with synthdef symbol arg and name', () => {
+		const { parseErrors } = parse('mono(\\moog) bass [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
@@ -55,30 +56,30 @@ describe('patternStatement — mono', () => {
 });
 
 describe('patternStatement — sample, slice, cloud', () => {
-	it('parses sample with a sequence body', () => {
-		const { parseErrors } = parse('sample [0 1 2]');
+	it('parses sample with a name and sequence body', () => {
+		const { parseErrors } = parse('sample drums [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses slice with a sequence body', () => {
-		const { parseErrors } = parse('slice [0 1 2]');
+	it('parses slice with a name and sequence body', () => {
+		const { parseErrors } = parse('slice loop [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses cloud with a sequence body', () => {
-		const { parseErrors } = parse('cloud [0 1 2]');
+	it('parses cloud with a name and sequence body', () => {
+		const { parseErrors } = parse('cloud pad [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 });
 
 describe('patternStatement — synthdef and full form', () => {
-	it('parses note with synthdef symbol arg', () => {
-		const { parseErrors } = parse('note(\\moog) [0 2 4]');
+	it('parses note with synthdef symbol arg and name', () => {
+		const { parseErrors } = parse('note(\\moog) lead [0 2 4]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
 	it('rejects note with string synthdef arg (strings are errors)', () => {
-		const { lexErrors } = parse('note("moog") [0 2 4]');
+		const { lexErrors } = parse('note("moog") lead [0 2 4]');
 		expect(lexErrors.length).toBeGreaterThan(0);
 	});
 });
@@ -125,153 +126,153 @@ describe('masterFxStatement', () => {
 });
 
 describe('accidentals', () => {
-	it('parses a flat degree: note [2b]', () => {
-		const { parseErrors } = parse('note [2b]');
+	it('parses a flat degree: note lead [2b]', () => {
+		const { parseErrors } = parse('note lead [2b]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses a sharp degree: note [4#]', () => {
-		const { parseErrors } = parse('note [4#]');
+	it('parses a sharp degree: note lead [4#]', () => {
+		const { parseErrors } = parse('note lead [4#]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses double flat: note [3bb]', () => {
-		const { parseErrors } = parse('note [3bb]');
+	it('parses double flat: note lead [3bb]', () => {
+		const { parseErrors } = parse('note lead [3bb]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses double sharp: note [4##]', () => {
-		const { parseErrors } = parse('note [4##]');
+	it('parses double sharp: note lead [4##]', () => {
+		const { parseErrors } = parse('note lead [4##]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses a mixed list with accidentals: note [0 2b 4#]', () => {
-		const { parseErrors } = parse('note [0 2b 4#]');
+	it('parses a mixed list with accidentals: note lead [0 2b 4#]', () => {
+		const { parseErrors } = parse('note lead [0 2b 4#]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('errors on accidental after generator expression: note [0rand4b]', () => {
+	it('errors on accidental after generator expression: note lead [0rand4b]', () => {
 		// 0rand4b — `b` after `4` in a generator context should be a lex/parse error
 		// because degreeLiterals are only plain integers, not generators
-		const { parseErrors, lexErrors } = parse('note [0rand4b]');
+		const { parseErrors, lexErrors } = parse('note lead [0rand4b]');
 		expect(parseErrors.length + lexErrors.length).toBeGreaterThan(0);
 	});
 });
 
 describe('transposition', () => {
-	it('parses note with + transposition: note [0 2] + 3', () => {
-		const { parseErrors } = parse('note [0 2] + 3');
+	it('parses note with + transposition: note lead [0 2] + 3', () => {
+		const { parseErrors } = parse('note lead [0 2] + 3');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses note with - transposition: note [0 2] - 1', () => {
-		const { parseErrors } = parse('note [0 2] - 1');
+	it('parses note with - transposition: note lead [0 2] - 1', () => {
+		const { parseErrors } = parse('note lead [0 2] - 1');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses transposition with generator RHS: note [0 2] + 0rand3', () => {
-		const { parseErrors } = parse('note [0 2] + 0rand3');
+	it('parses transposition with generator RHS: note lead [0 2] + 0rand3', () => {
+		const { parseErrors } = parse('note lead [0 2] + 0rand3');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('errors on double-negative transposition: note [0] - -4', () => {
-		const { parseErrors } = parse('note [0] - -4');
+	it('errors on double-negative transposition: note lead [0] - -4', () => {
+		const { parseErrors } = parse('note lead [0] - -4');
 		expect(parseErrors.length).toBeGreaterThan(0);
 	});
 });
 
 describe('continuation modifiers', () => {
 	it('parses a continuation modifier on an indented line', () => {
-		const { parseErrors } = parse("note [0 1]\n  'stut(2)");
+		const { parseErrors } = parse("note lead [0 1]\n  'stut(2)");
 		expect(parseErrors).toHaveLength(0);
 	});
 
 	it('parses multiple continuation modifiers', () => {
-		const { parseErrors } = parse("note [0 1]\n  'stut(2)\n  'legato(0.8)");
+		const { parseErrors } = parse("note lead [0 1]\n  'stut(2)\n  'legato(0.8)");
 		expect(parseErrors).toHaveLength(0);
 	});
 });
 
 describe('decorators', () => {
-	it('parses an inline decorator with symbol: @scale(\\minor) note [0 1 2]', () => {
-		const { parseErrors } = parse('@scale(\\minor) note [0 1 2]');
+	it('parses an inline decorator with symbol: @scale(\\minor) note lead [0 1 2]', () => {
+		const { parseErrors } = parse('@scale(\\minor) note lead [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
 	it('parses a block decorator with symbol', () => {
-		const { parseErrors } = parse('@scale(\\minor)\n  note [0 1 2]');
+		const { parseErrors } = parse('@scale(\\minor)\n  note lead [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses @key compound decorator: @key(g# lydian) note [0]', () => {
-		const { parseErrors } = parse('@key(g# lydian) note [0]');
+	it('parses @key compound decorator: @key(g# lydian) note lead [0]', () => {
+		const { parseErrors } = parse('@key(g# lydian) note lead [0]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
 	it('parses nested decorator blocks with symbol', () => {
-		const src = '@root(7)\n  @scale(\\minor)\n    note [0 1 2]';
+		const src = '@root(7)\n  @scale(\\minor)\n    note lead [0 1 2]';
 		const { parseErrors } = parse(src);
 		expect(parseErrors).toHaveLength(0);
 	});
 });
 
 describe('timed lists', () => {
-	it('parses relative timed list: note [4@1/2 7@1/4]', () => {
-		const { parseErrors } = parse('note [4@1/2 7@1/4]');
+	it('parses relative timed list: note lead [4@1/2 7@1/4]', () => {
+		const { parseErrors } = parse('note lead [4@1/2 7@1/4]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses timed list with integer-only time: note [0@0 4@1]', () => {
-		const { parseErrors } = parse('note [0@0 4@1]');
+	it('parses timed list with integer-only time: note lead [0@0 4@1]', () => {
+		const { parseErrors } = parse('note lead [0@0 4@1]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses relative timed list where first element has no @: note [0 2@1]', () => {
-		const { parseErrors } = parse('note [0 2@1]');
+	it('parses relative timed list where first element has no @: note lead [0 2@1]', () => {
+		const { parseErrors } = parse('note lead [0 2@1]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses relative timed list with @ on a later element: note [0 4 7@1/2]', () => {
-		const { parseErrors } = parse('note [0 4 7@1/2]');
+	it('parses relative timed list with @ on a later element: note lead [0 4 7@1/2]', () => {
+		const { parseErrors } = parse('note lead [0 4 7@1/2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses relative timed list with accidental before @: note [0 2b@1/4]', () => {
-		const { parseErrors } = parse('note [0 2b@1/4]');
+	it('parses relative timed list with accidental before @: note lead [0 2b@1/4]', () => {
+		const { parseErrors } = parse('note lead [0 2b@1/4]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses float time: note [0 2@1.5]', () => {
-		const { parseErrors } = parse('note [0 2@1.5]');
+	it('parses float time: note lead [0 2@1.5]', () => {
+		const { parseErrors } = parse('note lead [0 2@1.5]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses float time at cycle start: note [0@0.0 4@0.5]', () => {
-		const { parseErrors } = parse('note [0@0.0 4@0.5]');
+	it('parses float time at cycle start: note lead [0@0.0 4@0.5]', () => {
+		const { parseErrors } = parse('note lead [0@0.0 4@0.5]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
 	it('parses timed list with mono content type', () => {
-		const { parseErrors } = parse('mono [4@1/2 7@1/4]');
+		const { parseErrors } = parse('mono bass [4@1/2 7@1/4]');
 		expect(parseErrors).toHaveLength(0);
 	});
 });
 
 describe('pipe / FX', () => {
-	it('parses note with fx pipe using symbol: note [0] | fx(\\lpf)', () => {
-		const { parseErrors } = parse('note [0] | fx(\\lpf)');
+	it('parses note with fx pipe using symbol: note lead [0] | fx(\\lpf)', () => {
+		const { parseErrors } = parse('note lead [0] | fx(\\lpf)');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it("parses fx with modifier: note [0] | fx(\\lpf)'cutoff(1200)", () => {
-		const { parseErrors } = parse("note [0] | fx(\\lpf)'cutoff(1200)");
+	it("parses fx with modifier: note lead [0] | fx(\\lpf)'cutoff(1200)", () => {
+		const { parseErrors } = parse("note lead [0] | fx(\\lpf)'cutoff(1200)");
 		expect(parseErrors).toHaveLength(0);
 	});
 });
 
 describe('multiple statements', () => {
-	it('parses multiple statements on separate lines', () => {
-		const src = 'note [0 2 4]\nmono [0 1 2]\nset scale(\\minor)';
+	it('parses multiple named statements on separate lines', () => {
+		const src = 'note lead [0 2 4]\nmono bass [0 1 2]\nset scale(\\minor)';
 		const { parseErrors } = parse(src);
 		expect(parseErrors).toHaveLength(0);
 	});
@@ -283,171 +284,171 @@ describe('multiple statements', () => {
 
 describe("modifierSuffix — timing: 'lock and 'eager", () => {
 	it("parses bare 'lock on a list", () => {
-		expect(parse("note [0 2 4]'lock").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'lock").parseErrors).toHaveLength(0);
 	});
 
 	it("parses bare 'eager (shorthand for eager(1))", () => {
-		expect(parse("note [0 2 4]'eager").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'eager").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'eager(1) on a list", () => {
-		expect(parse("note [0 2 4]'eager(1)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'eager(1)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'eager(4) on a list", () => {
-		expect(parse("note [0 2 4]'eager(4)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'eager(4)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'lock on an element inside a list", () => {
-		expect(parse("note [0rand7'lock 2 4]").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0rand7'lock 2 4]").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'eager(2) on an element inside a list", () => {
-		expect(parse("note [0rand7'eager(2) 2 4]").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0rand7'eager(2) 2 4]").parseErrors).toHaveLength(0);
 	});
 
 	it("parses inner 'lock beating outer 'eager(3)", () => {
-		expect(parse("note [0rand7'lock]'eager(3)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0rand7'lock]'eager(3)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses inner 'eager(2) beating outer 'lock", () => {
-		expect(parse("note [0rand7'eager(2)]'lock").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0rand7'eager(2)]'lock").parseErrors).toHaveLength(0);
 	});
 });
 
 describe("modifierSuffix — sequence traversal: 'shuf, 'pick, 'wran", () => {
 	it("parses 'shuf on a list", () => {
-		expect(parse("note [0 1 2 3]'shuf").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2 3]'shuf").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'pick on a list", () => {
-		expect(parse("note [0 1 2 3]'pick").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2 3]'pick").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'wran on a list with weights", () => {
-		expect(parse("note [0?2 1?1 2?3]'wran").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0?2 1?1 2?3]'wran").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'wran on a list without explicit weights", () => {
-		expect(parse("note [0 1 2]'wran").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'wran").parseErrors).toHaveLength(0);
 	});
 });
 
 describe("modifierSuffix — filter: 'stut and 'maybe", () => {
 	it("parses bare 'stut (default count 2)", () => {
-		expect(parse("note [0 2 4]'stut").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'stut").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'stut(4) with fixed count", () => {
-		expect(parse("note [0 2 4]'stut(4)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'stut(4)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'stut with random count: 'stut(2rand4)", () => {
-		expect(parse("note [0 2 4]'stut(2rand4)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'stut(2rand4)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'stut with locked count: 'stut(2rand4'lock)", () => {
-		expect(parse("note [0 2 4]'stut(2rand4'lock)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'stut(2rand4'lock)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'stut with eager count: 'stut(2rand4'eager(4))", () => {
-		expect(parse("note [0 2 4]'stut(2rand4'eager(4))").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'stut(2rand4'eager(4))").parseErrors).toHaveLength(0);
 	});
 
 	it("parses bare 'maybe (default p 0.5)", () => {
-		expect(parse("note [0 2 4]'maybe").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'maybe").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'maybe(0.8) with explicit probability", () => {
-		expect(parse("note [0 2 4]'maybe(0.8)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'maybe(0.8)").parseErrors).toHaveLength(0);
 	});
 });
 
 describe("modifierSuffix — scheduling: 'n, 'at, 'legato, 'offset", () => {
 	it("parses bare 'n (play once)", () => {
-		expect(parse("note [0 1 2]'n").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'n").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'n(4)", () => {
-		expect(parse("note [0 1 2]'n(4)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'n(4)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'at(0) integer offset", () => {
-		expect(parse("note [0 1 2]'at(0)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'at(0)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'at(3/4) fractional offset", () => {
-		expect(parse("note [0 1 2]'at(3/4)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'at(3/4)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'at(1) whole-cycle offset", () => {
-		expect(parse("note [0 1 2]'at(1)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'at(1)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'at(-1/8) negative fractional offset", () => {
-		expect(parse("note [0 1 2]'at(-1/8)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'at(-1/8)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'n combined with 'at: 'n'at(1/4)", () => {
-		expect(parse("note [0 1 2]'n'at(1/4)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 1 2]'n'at(1/4)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'legato(0.8)", () => {
-		expect(parse("note [0 2 4]'legato(0.8)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'legato(0.8)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'legato with stochastic arg: 'legato(0.5rand1.2)", () => {
-		expect(parse("note [0 2 4]'legato(0.5rand1.2)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'legato(0.5rand1.2)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'offset(20)", () => {
-		expect(parse("note [0 2 4]'offset(20)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'offset(20)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses 'offset with negative value: 'offset(-10)", () => {
-		expect(parse("note [0 2 4]'offset(-10)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'offset(-10)").parseErrors).toHaveLength(0);
 	});
 });
 
 describe('modifierSuffix — chaining', () => {
 	it("parses chained modifiers: 'eager(1)'stut(2)", () => {
-		expect(parse("note [0 2 4]'eager(1)'stut(2)").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0 2 4]'eager(1)'stut(2)").parseErrors).toHaveLength(0);
 	});
 
 	it("parses element modifier plus list modifier: [0rand7'lock 2]'shuf", () => {
-		expect(parse("note [0rand7'lock 2]'shuf").parseErrors).toHaveLength(0);
+		expect(parse("note lead [0rand7'lock 2]'shuf").parseErrors).toHaveLength(0);
 	});
 });
 
 describe('sequenceElement — !n inline repetition', () => {
-	it('parses note [1!4]', () => {
-		expect(parse('note [1!4]').parseErrors).toHaveLength(0);
+	it('parses note lead [1!4]', () => {
+		expect(parse('note lead [1!4]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses note [1!2 3!3]', () => {
-		expect(parse('note [1!2 3!3]').parseErrors).toHaveLength(0);
+	it('parses note lead [1!2 3!3]', () => {
+		expect(parse('note lead [1!2 3!3]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses note [0rand7!4]', () => {
-		expect(parse('note [0rand7!4]').parseErrors).toHaveLength(0);
+	it('parses note lead [0rand7!4]', () => {
+		expect(parse('note lead [0rand7!4]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses note [2b!2] — accidental + repetition', () => {
-		expect(parse('note [2b!2]').parseErrors).toHaveLength(0);
+	it('parses note lead [2b!2] — accidental + repetition', () => {
+		expect(parse('note lead [2b!2]').parseErrors).toHaveLength(0);
 	});
 });
 
 describe('BlockComment', () => {
 	it('ignores a block comment before a note statement', () => {
-		expect(parse('/* comment */ note [0 2 4]').parseErrors).toHaveLength(0);
+		expect(parse('/* comment */ note lead [0 2 4]').parseErrors).toHaveLength(0);
 	});
 
 	it('ignores a multi-line block comment', () => {
-		expect(parse('/* line one\nline two */ note [0]').parseErrors).toHaveLength(0);
+		expect(parse('/* line one\nline two */ note lead [0]').parseErrors).toHaveLength(0);
 	});
 
 	it('ignores a block comment on its own line', () => {
-		expect(parse('note [0]\n/* comment */\nnote [2]').parseErrors).toHaveLength(0);
+		expect(parse('note lead [0]\n/* comment */\nnote lead [2]').parseErrors).toHaveLength(0);
 	});
 });
 
@@ -464,33 +465,124 @@ describe('modifierSuffix — error cases', () => {
 		// Spec §12 says ' lock (with a space) should be a parse error.
 		// Chevrotain's error-recovery silently accepts it. This test documents the
 		// current behaviour so any future fix is detectable as a test change.
-		const { parseErrors } = parse("note [0]' lock");
+		const { parseErrors } = parse("note lead [0]' lock");
 		expect(parseErrors).toHaveLength(0);
 	});
 });
 
 describe('rests (_)', () => {
-	it('parses a rest in a note pattern: note [0 2 _ 4]', () => {
-		expect(parse('note [0 2 _ 4]').parseErrors).toHaveLength(0);
+	it('parses a rest in a note pattern: note lead [0 2 _ 4]', () => {
+		expect(parse('note lead [0 2 _ 4]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses a rest at the start: note [_ 2 4]', () => {
-		expect(parse('note [_ 2 4]').parseErrors).toHaveLength(0);
+	it('parses a rest at the start: note lead [_ 2 4]', () => {
+		expect(parse('note lead [_ 2 4]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses a rest at the end: note [0 2 _]', () => {
-		expect(parse('note [0 2 _]').parseErrors).toHaveLength(0);
+	it('parses a rest at the end: note lead [0 2 _]', () => {
+		expect(parse('note lead [0 2 _]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses a list of all rests: note [_ _ _]', () => {
-		expect(parse('note [_ _ _]').parseErrors).toHaveLength(0);
+	it('parses a list of all rests: note lead [_ _ _]', () => {
+		expect(parse('note lead [_ _ _]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses a rest in a mono pattern: mono [0 _ 2]', () => {
-		expect(parse('mono [0 _ 2]').parseErrors).toHaveLength(0);
+	it('parses a rest in a mono pattern: mono bass [0 _ 2]', () => {
+		expect(parse('mono bass [0 _ 2]').parseErrors).toHaveLength(0);
 	});
 
-	it('parses a nested sublist with a rest: note [0 [_ 2] 4]', () => {
-		expect(parse('note [0 [_ 2] 4]').parseErrors).toHaveLength(0);
+	it('parses a nested sublist with a rest: note lead [0 [_ 2] 4]', () => {
+		expect(parse('note lead [0 [_ 2] 4]').parseErrors).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Generator naming (issue #2)
+// ---------------------------------------------------------------------------
+
+describe('generator naming — valid forms', () => {
+	it('parses note with a name: note lead [0 2 4]', () => {
+		expect(parse('note lead [0 2 4]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses mono with a name: mono bass [0 1 2 3]', () => {
+		expect(parse('mono bass [0 1 2 3]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses sample with a name: sample drums [0 1 2]', () => {
+		expect(parse('sample drums [0 1 2]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses slice with a name: slice loop [0 1 2]', () => {
+		expect(parse('slice loop [0 1 2]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses cloud with a name: cloud pad [0 1 2]', () => {
+		expect(parse('cloud pad [0 1 2]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses note with synthdef and name: note(\\moog) lead [0 2 4]', () => {
+		expect(parse('note(\\moog) lead [0 2 4]').parseErrors).toHaveLength(0);
+	});
+
+	it("parses note with name and modifier: note lead [0 2 4]'stut(2)", () => {
+		expect(parse("note lead [0 2 4]'stut(2)").parseErrors).toHaveLength(0);
+	});
+
+	it('parses note with name and transposition: note lead [0 2 4] + 2', () => {
+		expect(parse('note lead [0 2 4] + 2').parseErrors).toHaveLength(0);
+	});
+
+	it('parses note with name and fx pipe: note lead [0 2 4] | fx(\\lpf)', () => {
+		expect(parse('note lead [0 2 4] | fx(\\lpf)').parseErrors).toHaveLength(0);
+	});
+
+	it('parses inline decorator with named generator: @scale(\\minor) note lead [0 1 2]', () => {
+		expect(parse('@scale(\\minor) note lead [0 1 2]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses block decorator with named generator', () => {
+		expect(parse('@scale(\\minor)\n  note lead [0 1 2]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses multiple named generators on separate lines', () => {
+		const src = 'note lead [0 2 4]\nmono bass [0 1 2]';
+		expect(parse(src).parseErrors).toHaveLength(0);
+	});
+});
+
+describe('generator naming — unnamed patterns are errors', () => {
+	it('errors on note without a name: note [0 2 4]', () => {
+		expect(parse('note [0 2 4]').parseErrors.length).toBeGreaterThan(0);
+	});
+
+	it('errors on mono without a name: mono [0 1 2 3]', () => {
+		expect(parse('mono [0 1 2 3]').parseErrors.length).toBeGreaterThan(0);
+	});
+
+	it('errors on sample without a name: sample [0 1 2]', () => {
+		expect(parse('sample [0 1 2]').parseErrors.length).toBeGreaterThan(0);
+	});
+
+	it('errors on note(\\synthdef) without a name: note(\\moog) [0 2 4]', () => {
+		expect(parse('note(\\moog) [0 2 4]').parseErrors.length).toBeGreaterThan(0);
+	});
+});
+
+describe('derived generators — child:parent syntax', () => {
+	it("parses derived generator: sample perc:drums 'at(1/8)", () => {
+		expect(parse("sample perc:drums 'at(1/8)").parseErrors).toHaveLength(0);
+	});
+
+	it('parses derived generator without modifiers: note harm:lead [0 4 7]', () => {
+		expect(parse('note harm:lead [0 4 7]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses derived generator with synthdef: note(\\moog) harm:lead [0 4 7]', () => {
+		expect(parse('note(\\moog) harm:lead [0 4 7]').parseErrors).toHaveLength(0);
+	});
+
+	it('parses derived generator with fx pipe', () => {
+		expect(parse('note harm:lead [0 4 7] | fx(\\lpf)').parseErrors).toHaveLength(0);
 	});
 });

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -80,6 +80,7 @@ import {
 	Flat,
 	Bang,
 	Rest,
+	Colon,
 	INDENT,
 	DEDENT
 } from './lexer.js';
@@ -256,7 +257,8 @@ class FluxParser extends CstParser {
 	// -------------------------------------------------------------------------
 
 	patternStatement = this.RULE('patternStatement', () => {
-		// `note [...]`  or  `mono [...]`  or  `note(\synthdef) [...]`  etc.
+		// `note name [...]`  or  `note(\synthdef) name [...]`  or
+		// `note child:parent [...]` (derived generator)
 		// All content type keywords share the same grammar shape.
 		this.OR([
 			{ ALT: () => this.CONSUME(Note) },
@@ -268,6 +270,12 @@ class FluxParser extends CstParser {
 		this.OPTION(() => {
 			this.SUBRULE(this.synthdefArg);
 		});
+		// Mandatory generator name: either `name` (plain) or `child:parent` (derived).
+		this.SUBRULE(this.generatorName);
+		// For derived generators (child:parent), the sequence body is optional —
+		// the parent's pattern is inherited. For plain names, body is required.
+		// We use OPTION3 here but only conditionally: Chevrotain's alternative-based
+		// approach means we use OR2 with a derived-optional fallback.
 		this.OR2([
 			// timedList: '[' containing at least one 'degree@time' element.
 			// GATE peeks ahead to detect '@' inside the brackets.
@@ -275,7 +283,16 @@ class FluxParser extends CstParser {
 				GATE: () => this.isRelTimedList(),
 				ALT: () => this.SUBRULE(this.relTimedList)
 			},
-			{ ALT: () => this.SUBRULE(this.sequenceExpr) }
+			{ ALT: () => this.SUBRULE(this.sequenceExpr) },
+			// Derived generator with no body — body is optional for child:parent form.
+			// Detected by the absence of '[' as the next token.
+			// The evaluator enforces that only derived (child:parent) names may omit the body.
+			{
+				GATE: () => this.LA(1).tokenType !== LBracket,
+				ALT: () => {
+					/* no body — inherited from parent */
+				}
+			}
 		]);
 		this.MANY(() => {
 			this.SUBRULE(this.modifierSuffix);
@@ -328,6 +345,23 @@ class FluxParser extends CstParser {
 		this.CONSUME(LParen);
 		this.CONSUME(Symbol);
 		this.CONSUME(RParen);
+	});
+
+	/**
+	 * Generator name: either a plain identifier (`lead`) or a derived
+	 * child:parent reference (`perc:drums`).
+	 *
+	 * CST children:
+	 *   - Identifier[0] — the child/plain name
+	 *   - Colon[0]      — present only for derived generators
+	 *   - Identifier[1] — the parent name (only for derived generators)
+	 */
+	generatorName = this.RULE('generatorName', () => {
+		this.CONSUME(Identifier); // child name (or plain name)
+		this.OPTION(() => {
+			this.CONSUME(Colon);
+			this.CONSUME2(Identifier); // parent name
+		});
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Mandatory generator names**: all content type statements (`note`, `mono`, `sample`, etc.) now require a name between the keyword and the generator expression — `note lead [0 1 2 3]`. Unnamed patterns are a parse error.
- **Derived generators** (`child:parent` syntax): `note over:lead + 2` inherits the parent's pattern and params, overriding only what's specified. Produces a parallel event stream alongside the parent.
- **Static validation**: duplicate names within a single evaluation and dangling derived references (parent not present) are caught before any audio changes are made, with descriptive errors.
- **`reinit()` on `EvalInstance`**: re-compiles from new source while preserving runner state (locked values, eager cycles) for unchanged named generators — enabling live coding continuity.
- **Spec updated**: new "Generator naming" section added to `DSL-spec.md`; all unnamed examples updated throughout.

## Changes

- `docs/DSL-spec.md` — new Generator naming section, updated all examples
- `src/lib/lang/lexer.ts` — added `Colon` to `allTokens` (was defined but not registered)
- `src/lib/lang/parser.ts` — `generatorName` rule (plain `name` | `child:parent`), mandatory in `patternStatement`; `Colon` imported
- `src/lib/lang/evaluator.ts` — two-pass `compileSource` for parent resolution, `validateNames`, `transferRunnerState`, `reinit()`, derived element inheritance
- `src/lib/lang/parser.test.ts` — all existing tests updated to use named forms; new naming and derived syntax tests
- `src/lib/lang/evaluator.test.ts` — all existing tests updated to use named forms; new static error and `reinit()` tests

## Test plan

- [ ] `pnpm test` — 599 tests passing
- [ ] `pnpm check` — 0 type errors
- [ ] `note lead [0 1 2 3]` + `note over:lead + 2` produces 8 events (4 lead + 4 over, transposed up 2 degrees)
- [ ] `note lead [0 2 4]\nnote lead [0 1]` returns `ok: false` with duplicate name error
- [ ] `note perc:drums [0 2 4]` (no `drums` present) returns `ok: false` with dangling ref error
- [ ] `reinit()` with new source updates events; `reinit()` preserves locked runner values for unchanged names

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)