### PR TITLE
feat(lang): bare identifiers for scale/key, \symbol for runtime artefacts

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -346,7 +346,7 @@ Accidentals are interpreted as literals at parse time — `2b` is a single token
 `set` is a top-level statement for setting ambient session parameters that apply globally unless overridden. This avoids modifier sprawl and prevents the DSL from reinventing Pbind-style key-value pairs piecemeal.
 
 ```flux
-set scale(\minor)
+set scale(minor)
 set root(7)
 set tempo(120)
 set key(g# lydian)
@@ -361,21 +361,21 @@ Parameters: `scale`, `root`, `octave`, `tempo`, `cent`, `key`.
 `@` decorators apply session parameters to a scoped block of expressions, overriding global `set` values within that scope. They use a parenthesised argument list — the same syntax supports single arguments (`@root(7)`), compound arguments (`@key(g# lydian 4)`), and stochastic arguments (`@root(3rand7)`).
 
 ```flux
-@scale(\minor) @root(7)
+@scale(minor) @root(7)
   note lead [0 1 2]
   @octave(4)
     note lead [0 2 4 5]
 ```
 
-Here `note lead [0 1 2]` inherits `@scale(\minor)` and `@root(7)`. `note lead [0 2 4 5]` inherits all three, with `@octave(4)` added at the nested level.
+Here `note lead [0 1 2]` inherits `@scale(minor)` and `@root(7)`. `note lead [0 2 4 5]` inherits all three, with `@octave(4)` added at the nested level.
 
 For single-expression use, decorators may appear inline on the same line:
 
 ```flux
-@scale(\minor) note lead [0 1 2]
+@scale(minor) note lead [0 1 2]
 ```
 
-**`set` is `@` at global scope.** `set scale(\minor)` is sugar for a top-level `@scale(\minor)` with no indented body. They are the same mechanism at different scopes — `set` establishes session-wide defaults, `@` overrides them for a block.
+**`set` is `@` at global scope.** `set scale(minor)` is sugar for a top-level `@scale(minor)` with no indented body. They are the same mechanism at different scopes — `set` establishes session-wide defaults, `@` overrides them for a block.
 
 **Indentation:** block scope uses fixed indentation (2 spaces). Variable indentation is not supported — indentation level is determined by the number of leading 2-space units. This keeps the parser simple and the code visually consistent.
 
@@ -385,19 +385,35 @@ For single-expression use, decorators may appear inline on the same line:
 
 ---
 
-## Symbols
+## Name conventions
 
-Names in Flux — SynthDef names, FX names, and scale names passed as arguments — are written as **symbols**: a backslash immediately followed by an identifier, with no space.
+Flux uses two conventions for naming things, depending on whether the name refers to a runtime artefact or built-in language vocabulary.
+
+### `\symbol` — runtime artefacts
+
+SynthDef names, FX names, and buffer names are written as **symbols**: a backslash immediately followed by an identifier, with no space.
 
 ```flux
-\moog     // symbol whose name is "moog"
-\lpf      // symbol whose name is "lpf"
-\minor    // symbol whose name is "minor"
+\moog     // SynthDef name
+\lpf      // FX name
+\kit      // buffer name
 ```
 
-This is borrowed from SuperCollider. The backslash+identifier is a single token; whitespace between `\` and the name is not permitted.
+This is borrowed from SuperCollider. The backslash+identifier is a single token; whitespace between `\` and the name is not permitted. String literals (`"moog"`) are not valid in Flux — use symbols instead.
 
-String literals (`"moog"`) are not valid in Flux — use symbols instead.
+`\symbol` means "look this up in a runtime registry" — the set of valid names is open and user-extensible.
+
+### Bare identifiers — built-in vocabulary
+
+Scale names, key names, and root names are written as **bare identifiers** — no backslash.
+
+```flux
+set scale(minor)       // scale name — bare identifier
+set key(g# lydian)     // key name — bare identifier
+@scale(dorian) note lead [0 2 4]
+```
+
+Bare identifiers in these positions mean "this is a fixed, language-defined name" — the set of valid values is closed and defined by the language.
 
 ---
 

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -1788,11 +1788,9 @@ describe('accidentals in non-default pitch contexts', () => {
 		expect(notes('@root(7) note x [2#]')[0]).toBe(notes('@root(7) note x [2]')[0] + 1);
 	});
 
-	it('@scale(\\minor) note x [4b] — flat applied in minor context (degree 4 = G5 = 67, -1 = 66)', () => {
+	it('@scale(minor) note x [4b] — flat applied in minor context (degree 4 = G5 = 67, -1 = 66)', () => {
 		// C minor, degree 4 = G5 = 67 (minor has same perfect 5th), flat → 66 = F#5
-		expect(notes('@scale(\\minor) note x [4b]')[0]).toBe(
-			notes('@scale(\\minor) note x [4]')[0] - 1
-		);
+		expect(notes('@scale(minor) note x [4b]')[0]).toBe(notes('@scale(minor) note x [4]')[0] - 1);
 	});
 
 	it('@key(g major 4) note x [3#] — accidental in compound key context', () => {

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -670,18 +670,11 @@ function applyDecoratorToContext(
 
 /**
  * Extract a scale name from a decoratorArg node.
- * Scale names appear as Identifier tokens (e.g. minor) or Symbol tokens (e.g. \minor).
+ * Scale names are always bare Identifier tokens (e.g. minor, lydian).
  */
 function extractScaleNameFromArg(arg: CstNode): string | null {
-	// Identifier (e.g. minor, lydian, major_pentatonic)
 	const idTok = ((arg.children.Identifier as IToken[]) ?? [])[0];
-	if (idTok) return idTok.image;
-
-	// Symbol (e.g. \minor) — strip leading backslash
-	const symTok = ((arg.children.Symbol as IToken[]) ?? [])[0];
-	if (symTok) return symTok.image.slice(1);
-
-	return null;
+	return idTok ? idTok.image : null;
 }
 
 /**

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -85,8 +85,8 @@ describe('patternStatement — synthdef and full form', () => {
 });
 
 describe('setStatement', () => {
-	it('parses set scale(\\minor) with symbol', () => {
-		const { parseErrors } = parse('set scale(\\minor)');
+	it('parses set scale(minor) with bare identifier', () => {
+		const { parseErrors } = parse('set scale(minor)');
 		expect(parseErrors).toHaveLength(0);
 	});
 
@@ -98,6 +98,52 @@ describe('setStatement', () => {
 	it('parses set tempo(120)', () => {
 		const { parseErrors } = parse('set tempo(120)');
 		expect(parseErrors).toHaveLength(0);
+	});
+});
+
+describe('name conventions — \\symbol vs bare identifier', () => {
+	// Scale/key positions take bare identifiers only (closed, built-in vocabulary).
+	// \\symbol is reserved for SynthDef/FX names (open, runtime registry).
+
+	it('set scale(minor) — bare identifier is accepted', () => {
+		expect(parse('set scale(minor)').parseErrors).toHaveLength(0);
+	});
+
+	it('set scale(\\minor) — symbol is a parse error in scale position', () => {
+		expect(parse('set scale(\\minor)').parseErrors.length).toBeGreaterThan(0);
+	});
+
+	it('@scale(minor) — bare identifier is accepted inline', () => {
+		expect(parse('@scale(minor) note lead [0 1 2]').parseErrors).toHaveLength(0);
+	});
+
+	it('@scale(\\minor) — symbol is a parse error in @scale position', () => {
+		expect(parse('@scale(\\minor) note lead [0 1 2]').parseErrors.length).toBeGreaterThan(0);
+	});
+
+	it('@scale(dorian) — other scale names work as bare identifiers', () => {
+		expect(parse('@scale(dorian) note lead [0 2 4]').parseErrors).toHaveLength(0);
+	});
+
+	it('set key(g# lydian) — bare identifiers accepted in key position', () => {
+		expect(parse('set key(g# lydian)').parseErrors).toHaveLength(0);
+	});
+
+	// SynthDef positions still require \\symbol (not bare identifier).
+	it('note(\\moog) lead [...] — symbol is required for SynthDef', () => {
+		expect(parse('note(\\moog) lead [0 1 2]').parseErrors).toHaveLength(0);
+	});
+
+	it('note(moog) lead [...] — bare identifier is rejected in SynthDef position', () => {
+		expect(parse('note(moog) lead [0 1 2]').parseErrors.length).toBeGreaterThan(0);
+	});
+
+	it('fx(\\lpf) — symbol is required for FX name', () => {
+		expect(parse('note lead [0 2 4] | fx(\\lpf)').parseErrors).toHaveLength(0);
+	});
+
+	it('fx(lpf) — bare identifier is rejected in FX position', () => {
+		expect(parse('note lead [0 2 4] | fx(lpf)').parseErrors.length).toBeGreaterThan(0);
 	});
 });
 
@@ -194,13 +240,13 @@ describe('continuation modifiers', () => {
 });
 
 describe('decorators', () => {
-	it('parses an inline decorator with symbol: @scale(\\minor) note lead [0 1 2]', () => {
-		const { parseErrors } = parse('@scale(\\minor) note lead [0 1 2]');
+	it('parses an inline decorator: @scale(minor) note lead [0 1 2]', () => {
+		const { parseErrors } = parse('@scale(minor) note lead [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses a block decorator with symbol', () => {
-		const { parseErrors } = parse('@scale(\\minor)\n  note lead [0 1 2]');
+	it('parses a block decorator with bare identifier', () => {
+		const { parseErrors } = parse('@scale(minor)\n  note lead [0 1 2]');
 		expect(parseErrors).toHaveLength(0);
 	});
 
@@ -209,8 +255,8 @@ describe('decorators', () => {
 		expect(parseErrors).toHaveLength(0);
 	});
 
-	it('parses nested decorator blocks with symbol', () => {
-		const src = '@root(7)\n  @scale(\\minor)\n    note lead [0 1 2]';
+	it('parses nested decorator blocks', () => {
+		const src = '@root(7)\n  @scale(minor)\n    note lead [0 1 2]';
 		const { parseErrors } = parse(src);
 		expect(parseErrors).toHaveLength(0);
 	});
@@ -272,7 +318,7 @@ describe('pipe / FX', () => {
 
 describe('multiple statements', () => {
 	it('parses multiple named statements on separate lines', () => {
-		const src = 'note lead [0 2 4]\nmono bass [0 1 2]\nset scale(\\minor)';
+		const src = 'note lead [0 2 4]\nmono bass [0 1 2]\nset scale(minor)';
 		const { parseErrors } = parse(src);
 		expect(parseErrors).toHaveLength(0);
 	});
@@ -537,12 +583,12 @@ describe('generator naming — valid forms', () => {
 		expect(parse('note lead [0 2 4] | fx(\\lpf)').parseErrors).toHaveLength(0);
 	});
 
-	it('parses inline decorator with named generator: @scale(\\minor) note lead [0 1 2]', () => {
-		expect(parse('@scale(\\minor) note lead [0 1 2]').parseErrors).toHaveLength(0);
+	it('parses inline decorator with named generator: @scale(minor) note lead [0 1 2]', () => {
+		expect(parse('@scale(minor) note lead [0 1 2]').parseErrors).toHaveLength(0);
 	});
 
 	it('parses block decorator with named generator', () => {
-		expect(parse('@scale(\\minor)\n  note lead [0 1 2]').parseErrors).toHaveLength(0);
+		expect(parse('@scale(minor)\n  note lead [0 1 2]').parseErrors).toHaveLength(0);
 	});
 
 	it('parses multiple named generators on separate lines', () => {

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -447,17 +447,16 @@ class FluxParser extends CstParser {
 	});
 
 	decoratorArg = this.RULE('decoratorArg', () => {
-		// pitchClass (e.g. g#, Ab) or generatorExpr (e.g. 3rand7, 120) or symbol (e.g. \minor)
+		// pitchClass (e.g. g#, Ab), bare identifier (e.g. minor, lydian), or numeric generator.
+		// \symbol is intentionally NOT accepted here — scale/key names are closed, built-in vocabulary.
 		this.OR([
 			// pitchClass: a single-char identifier [a-gA-G] optionally followed by Sharp/Flat
 			{
 				GATE: () => this.isPitchClass(),
 				ALT: () => this.SUBRULE(this.pitchClass)
 			},
-			// Scale names and other identifiers (e.g. lydian, minor)
+			// Scale names and other bare identifiers (e.g. lydian, minor, dorian)
 			{ ALT: () => this.CONSUME(Identifier) },
-			// Symbol literals for names: set scale(\minor), @scale(\minor)
-			{ ALT: () => this.CONSUME(Symbol) },
 			// Numeric generator expressions: @root(3rand7), set tempo(120)
 			{ ALT: () => this.SUBRULE(this.numericGenerator) }
 		]);


### PR DESCRIPTION
Closes #3

## Summary

- `\symbol` is now exclusively for SynthDef names, FX names, and buffer names (open, runtime registry)
- Bare identifiers (`minor`, `lydian`, `dorian`, …) are now the only valid syntax for scale/key names (closed, built-in vocabulary)
- `\minor` in `set scale(…)` or `@scale(…)` is a parse error

## Changes

- **`parser.ts`** — removed `Symbol` alternative from `decoratorArg` rule
- **`evaluator.ts`** — removed dead Symbol-stripping branch from `extractScaleNameFromArg`
- **`DSL-spec.md`** — replaced "Symbols" section with "Name conventions" explaining the distinction; updated all examples
- **Tests** — added 10 new parser tests covering the convention boundary; updated all existing tests that used `\minor` in scale position

## Test plan

- [ ] `set scale(minor)` / `@scale(dorian)` parse without errors
- [ ] `set scale(\minor)` / `@scale(\minor)` produce parse errors
- [ ] `note(\moog) lead [...]` still accepted; `note(moog) lead [...]` still rejected
- [ ] `fx(\lpf)` still accepted; `fx(lpf)` still rejected
- [ ] `pnpm test` — 609/609 passing
- [ ] `pnpm check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)