### PR TITLE
feat(lang): three syntactic roles — spec and "param implementation (#8)

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -379,8 +379,6 @@ For single-expression use, decorators may appear inline on the same line:
 
 **Indentation:** block scope uses fixed indentation (2 spaces). Variable indentation is not supported — indentation level is determined by the number of leading 2-space units. This keeps the parser simple and the code visually consistent.
 
-**Decorator vs. modifier boundary:** the distinction is functional, not syntactic. **Decorators (`@`) affect how the numbers inside `[]` are used to calculate the final pitch** — they are parameters in the degree-to-frequency chain: `degree → scale → root → octave → cent → frequency`. **Modifiers (`'`) are everything else** — operations on the event stream or synth parameters.
-
 **Stochastic decorator arguments** follow the same `'lock`/`'eager(n)` semantics as everything else. `@root(3rand7)` with `'eager(4)` redraws every 4 cycles; with `'lock` the value is drawn once when the block is first entered and frozen thereafter. `'lock` is the sensible default for decorators — a randomly wandering root is an opt-in, not the default.
 
 ---
@@ -531,11 +529,31 @@ note lead [0 2 4 7] | fx(\lpf)'cutoff(1200)'tail(0)   // free immediately when s
 
 ---
 
+## Three syntactic roles
+
+Three prefix characters serve distinct, non-overlapping roles in the DSL. Understanding the boundary between them is essential for reading and writing Flux code.
+
+| Sigil | Role      | What it does                                                                                                                                                                                                                                                                   |
+| ----- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@`   | Decorator | Language-side pitch calculation. Sets parameters in the degree-to-frequency chain (`root`, `scale`, `octave`, `cent`). Always translates musical intent — never a raw synth argument passthrough.                                                                              |
+| `'`   | Modifier  | Transforms the event stream or controls generator behaviour. Agnostic about content: `'stut`, `'legato`, `'lock`, `'eager`, etc. Never touches raw synth arguments directly.                                                                                                   |
+| `"`   | Param     | Direct synth argument access. Bypasses language abstractions and sends a value straight to a named SynthDef parameter. Intentionally unglamorous — heavy reliance on `"param` is a signal to reconsider the SynthDef design or elevate the parameter to a first-class concept. |
+
+The three mechanisms are mutually exclusive in what they can express:
+
+- `@root(7)` is a decorator — it participates in pitch calculation.
+- `'legato(0.8)` is a modifier — it shapes the event stream.
+- `"amp(0.5)` is a param — it passes `0.5` directly to the `amp` argument of the current SynthDef.
+
+No sigil can substitute for another. Using `'amp(0.5)` to set amplitude is not valid — `amp` is a SynthDef argument, not a stream modifier.
+
+---
+
 ## Modifier syntax
 
 > _See truth tables [1 (Modifier attachment)](DSL-truthtables.md#1-modifier-attachment-truth-table) and [2 (Modifier precedence)](DSL-truthtables.md#2-modifier-precedence-truth-table)._
 
-The sign `'` in an expression like `x'y` indicates a **modifier**, i.e. that `y` modifies the behaviour of `x`.
+The sign `'` in an expression like `x'y` indicates a **modifier**, i.e. that `y` modifies the behaviour of `x`. Modifiers are strictly for stream and generator operations — they do not provide direct access to SynthDef arguments. Use `"param` notation for that (see below).
 
 Modifiers are methods that return `this`, so chaining is supported:
 
@@ -592,6 +610,35 @@ note lead [0 2 4] + 0rand3
 ```
 
 The parser distinguishes modifier continuations from decorator block bodies by the leading `'` character on the indented line.
+
+### `"param` — direct SynthDef argument access
+
+> _See truth table [18 (`"param`)](DSL-truthtables.md#18-param-truth-table)._
+
+`"param(value)` sends a value directly to a named SynthDef argument, bypassing the language's pitch and stream abstractions. It is valid anywhere a modifier is valid.
+
+The token form is `"` immediately followed by an identifier, with no whitespace — analogous to `\symbol`. The `"identifier` is a single token.
+
+```flux
+note [0 2 4]"amp(0.5)            // set amp to 0.5
+note [0 2 4]"amp(0.5)"pan(-0.3)  // chained: set amp and pan
+note [0 2 4] | fx(\lpf)"cutoff(800)"rq(0.3)  // on FX node
+```
+
+The value argument accepts the same expressions as modifiers — literals, generators, stochastic expressions:
+
+```flux
+note [0 2 4]"amp(0.3rand0.8)              // stochastic amp, eager(1) by default
+note [0 2 4]"amp(0.3rand0.8'eager(4))     // redraw every 4 cycles
+note [0 2 4]"amp(0.3rand0.8'lock)         // freeze at first drawn value
+```
+
+**SynthDef parameter names** come from the SynthDef's `specs` object in `static/compiled_synthdefs/metadata.json`. Each key is a parameter name (e.g. `amp`, `pan`, `rel`); the value carries `{ default, min, max, unit, curve }`. The active SynthDef is determined by the `\symbol` argument on the content type keyword (`note(\kick)` → look up `kick`). Parameter names are lowercase identifiers.
+
+**Tooling:**
+
+- The completion provider offers parameter names on `"` trigger, prefix-filtered as the user types.
+- The hover provider shows `min`, `max`, `default`, and `unit` for a hovered `"param` token.
 
 ---
 

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -346,6 +346,28 @@ Monophonic mode via the `mono` content type keyword.
 
 ---
 
+# 18. **`"param` Truth Table**
+
+Direct SynthDef argument access. Valid wherever modifiers are valid.
+
+| Code                                    | Interpretation              | Evaluation                           | Result                       |
+| --------------------------------------- | --------------------------- | ------------------------------------ | ---------------------------- |
+| `note [0 2 4]"amp(0.5)`                 | Set `amp` to literal.       | Value passed straight to synth node. | Amplitude fixed at 0.5.      |
+| `note [0 2 4]"amp(0.5)"pan(-0.3)`       | Chained params.             | Each param applied independently.    | Both amp and pan set.        |
+| `note [0 2 4]"amp(0.3rand0.8)`          | Stochastic value, eager(1). | Value drawn once per cycle.          | Amplitude varies per cycle.  |
+| `note [0 2 4]"amp(0.3rand0.8'eager(4))` | Redraw every 4 cycles.      | Value held 4 cycles then redrawn.    | Slowly varying amplitude.    |
+| `note [0 2 4]"amp(0.3rand0.8'lock)`     | Frozen value.               | Drawn once at first eval, frozen.    | Same amplitude forever.      |
+| `note [0 2 4] \| fx(\lpf)"cutoff(800)`  | Param on FX node.           | cutoff passed to FX synth node.      | Filter cutoff set to 800 Hz. |
+
+**Error cases**
+
+| Code                 | Failure Type | Why                                                     |
+| -------------------- | ------------ | ------------------------------------------------------- |
+| `"amp` alone         | Parse error  | Param token has no preceding expression to attach to.   |
+| `note [0]" amp(0.5)` | Lex error    | Whitespace between `"` and identifier is not permitted. |
+
+---
+
 # 17. **Error Condition Summary**
 
 | Code                  | Failure Type   | Why                                                 |

--- a/scripts/compile_synthdefs.scd
+++ b/scripts/compile_synthdefs.scd
@@ -37,6 +37,16 @@ Task({
 			try {
 				def.writeDefFile(~targetDir.fullPath);
 				~metadata.put(def.name, def.metadata ?? Dictionary.new);
+				~metadata[def.name].specs.keysValuesChange({
+					arg x, spec;
+					Dictionary.newFrom([
+						\min, spec.minval,
+						\max, spec.maxval,
+						\default, spec.default,
+						\curve, if(spec.warp.isKindOf(CurveWarp)) { spec.warp.curve } { 0 },
+						\unit, spec.units,
+					]);
+				});
 				~metadata[def.name].put(\source, file.fileName);
                 ~numSynthDefs = ~numSynthDefs + 1;
 			} {
@@ -50,11 +60,11 @@ Task({
 	~metadataFile = File.open(~metadataFilePath.fullPath, "w");
 	~metadataFile.write(~metadata.asJSON);
 	~metadataFile.close;
-    
+
     // Wait for a second before exiting to let any deferred .writeDefFile calls wrap up
     1.wait;
-    
+
     ("\nCompiled" + ~numSynthDefs + "SynthDefs").postln;
-    
+
     0.exit;
 }).play;

--- a/src/lib/lang/completions.test.ts
+++ b/src/lib/lang/completions.test.ts
@@ -12,7 +12,18 @@
 import { describe, it, expect } from 'vitest';
 import { FluxLexer } from './lexer.js';
 import { getCompletions } from './completions.js';
-import type { CompletionItem } from './completions.js';
+import type { CompletionItem, SynthDefMetadata } from './completions.js';
+
+// Inline fixture matching static/compiled_synthdefs/metadata.json shape
+const TEST_METADATA: SynthDefMetadata = {
+	kick: {
+		specs: {
+			amp: { default: 0.1, min: 0, max: 1, unit: 'amp', curve: 4 },
+			pan: { default: 0, min: -1, max: 1, unit: '', curve: 2 },
+			rel: { default: 0.2, min: 0.001, max: 4, unit: 'seconds', curve: 4 }
+		}
+	}
+};
 
 // ---------------------------------------------------------------------------
 // Helper — tokenize a snippet and return tokens
@@ -70,6 +81,60 @@ describe("getCompletions — trigger: '", () => {
 		const tokens = tokenize("note [0]'");
 		const items = getCompletions(tokens, endCursor("note [0]'"), "'");
 		expect(items.some((i: CompletionItem) => i.label === 'maybe(p)')).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 1b. Trigger character: " (param sigil)
+// ---------------------------------------------------------------------------
+
+describe('getCompletions — trigger: "', () => {
+	it("returns param completions for trigger char '\"'", () => {
+		const tokens = tokenize('note [0 2]"');
+		const items = getCompletions(tokens, endCursor('note [0 2]"'), '"', undefined, TEST_METADATA);
+		expect(items.length).toBeGreaterThan(0);
+	});
+
+	it('param completions include "amp" from kick SynthDef when activeSynthDef = "kick"', () => {
+		const tokens = tokenize('note [0 2]"');
+		const items = getCompletions(tokens, endCursor('note [0 2]"'), '"', 'kick', TEST_METADATA);
+		expect(items.some((i: CompletionItem) => i.label === 'amp')).toBe(true);
+	});
+
+	it('param completions include "pan" and "rel" for kick', () => {
+		const tokens = tokenize('note [0]"');
+		const items = getCompletions(tokens, endCursor('note [0]"'), '"', 'kick', TEST_METADATA);
+		expect(items.some((i: CompletionItem) => i.label === 'pan')).toBe(true);
+		expect(items.some((i: CompletionItem) => i.label === 'rel')).toBe(true);
+	});
+
+	it('param completions are snippet items with default value', () => {
+		const items = getCompletions([], 0, '"', 'kick', TEST_METADATA);
+		const amp = items.find((i: CompletionItem) => i.label === 'amp');
+		expect(amp).toBeDefined();
+		expect(amp?.isSnippet).toBe(true);
+		expect(amp?.insertText).toContain('${1:');
+	});
+
+	it('param completions include detail with range info', () => {
+		const items = getCompletions([], 0, '"', 'kick', TEST_METADATA);
+		const amp = items.find((i: CompletionItem) => i.label === 'amp');
+		expect(amp?.detail).toContain('amp');
+	});
+
+	it('with no activeSynthDef, returns params from all known synthdefs', () => {
+		const items = getCompletions([], 0, '"', undefined, TEST_METADATA);
+		expect(items.length).toBeGreaterThan(0);
+	});
+
+	it('returns empty array for unknown activeSynthDef', () => {
+		const items = getCompletions([], 0, '"', 'nonexistent_synth', TEST_METADATA);
+		expect(items).toHaveLength(0);
+	});
+
+	it('returns empty array when no metadata provided', () => {
+		const items = getCompletions([], 0, '"');
+		expect(items).toHaveLength(0);
 	});
 });
 

--- a/src/lib/lang/completions.ts
+++ b/src/lib/lang/completions.ts
@@ -9,6 +9,7 @@
  *
  * Completion is largely static table lookups driven by trigger characters:
  *   '    → offer modifier names: lock, eager, stut, legato, at, n, tail, offset, …
+ *   "    → offer SynthDef parameter names from metadata.json (prefix-filtered)
  *   [    → offer generators, scale degrees, literals
  *   (    → context-sensitive: synthdef names after note/mono/sample/slice/cloud/fx("…"), arg values after modifiers
  *   |    → offer fx("…") patterns
@@ -293,6 +294,69 @@ const SET_PARAM_COMPLETIONS: CompletionItem[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// SynthDef metadata types (exported for use by callers / Monaco adapter)
+// ---------------------------------------------------------------------------
+
+export type SynthDefSpecEntry = {
+	default: number;
+	min: number;
+	max: number;
+	unit: string;
+	curve: number;
+};
+export type SynthDefEntry = { specs: Record<string, SynthDefSpecEntry> };
+export type SynthDefMetadata = Record<string, SynthDefEntry>;
+
+// ---------------------------------------------------------------------------
+// SynthDef parameter completions
+// ---------------------------------------------------------------------------
+
+/**
+ * Build completion items for `"param` notation.
+ *
+ * @param synthdefMetadata - The loaded SynthDef metadata (from metadata.json via fetch).
+ * @param activeSynthDef - The SynthDef name currently in scope (e.g. "kick"),
+ *   or undefined to offer params from all known SynthDefs (deduped).
+ * @param prefix - Characters typed after `"`, used for prefix filtering.
+ */
+function getParamCompletions(
+	synthdefMetadata: SynthDefMetadata,
+	activeSynthDef?: string,
+	prefix = ''
+): CompletionItem[] {
+	const entries: [string, SynthDefSpecEntry][] = [];
+
+	if (activeSynthDef) {
+		// Specific SynthDef requested — return only its params (empty if not found).
+		if (activeSynthDef in synthdefMetadata) {
+			entries.push(...Object.entries(synthdefMetadata[activeSynthDef].specs));
+		}
+	} else {
+		// No active SynthDef — collect all params across all defs, deduplicated by name.
+		const seen = new Set<string>();
+		for (const def of Object.values(synthdefMetadata)) {
+			for (const [name, spec] of Object.entries(def.specs)) {
+				if (!seen.has(name)) {
+					seen.add(name);
+					entries.push([name, spec]);
+				}
+			}
+		}
+	}
+
+	return entries
+		.filter(([name]) => name.startsWith(prefix))
+		.map(([name, spec]) => ({
+			label: name,
+			insertText: `${name}(\${1:${spec.default}})`,
+			isSnippet: true,
+			detail: `"${name} — ${spec.unit ? `${spec.unit}, ` : ''}${spec.min}–${spec.max}, default ${spec.default}`,
+			documentation: `SynthDef parameter. Range: ${spec.min}–${spec.max}. Default: ${spec.default}.${spec.unit ? ` Unit: ${spec.unit}.` : ''}`,
+			kind: 'property' as CompletionItemKind
+		}));
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -320,11 +384,17 @@ function lastTokenBefore(tokens: IToken[], cursorOffset: number): IToken | undef
  * @param cursorOffset - Character offset of the cursor within the line.
  * @param triggerChar - The character that triggered the completion, or undefined
  *   for an explicit (Ctrl+Space) invocation.
+ * @param activeSynthDef - The SynthDef name in scope (e.g. "kick"), used for
+ *   `"param` completions. If undefined, all known param names are offered.
+ * @param synthdefMetadata - Runtime SynthDef metadata (loaded via fetch from
+ *   /compiled_synthdefs/metadata.json). If not provided, param completions are empty.
  */
 export function getCompletions(
 	tokens: IToken[],
 	cursorOffset: number,
-	triggerChar?: string
+	triggerChar?: string,
+	activeSynthDef?: string,
+	synthdefMetadata: SynthDefMetadata = {}
 ): CompletionItem[] {
 	const prev = lastTokenBefore(tokens, cursorOffset);
 	const prevType = prev?.tokenType.name;
@@ -332,6 +402,11 @@ export function getCompletions(
 	// ' trigger → modifier names
 	if (triggerChar === "'") {
 		return MODIFIER_COMPLETIONS;
+	}
+
+	// " trigger → SynthDef param names (prefix-filtered as user types)
+	if (triggerChar === '"') {
+		return getParamCompletions(synthdefMetadata, activeSynthDef);
 	}
 
 	// | trigger → fx patterns
@@ -358,6 +433,7 @@ export function getCompletions(
 
 	// Explicit invocation — infer from context
 	if (prevType === 'Tick') return MODIFIER_COMPLETIONS;
+	if (prevType === 'ParamSigil') return getParamCompletions(synthdefMetadata, activeSynthDef);
 	if (prevType === 'Pipe') return PIPE_COMPLETIONS;
 	if (prevType === 'LBracket') return SEQUENCE_BODY_COMPLETIONS;
 

--- a/src/lib/lang/highlighter.ts
+++ b/src/lib/lang/highlighter.ts
@@ -46,6 +46,8 @@ const TOKEN_CLASS: Record<string, string> = {
 	BlockComment: 'tok-comment',
 	// Identifiers
 	Identifier: 'tok-variable',
+	// Param sigil — visually distinct from 'modifier and \symbol
+	ParamSigil: 'tok-param',
 	// Operators & punctuation
 	Tick: 'tok-operator',
 	Flat: 'tok-operator',

--- a/src/lib/lang/hover.test.ts
+++ b/src/lib/lang/hover.test.ts
@@ -16,6 +16,17 @@ import { FluxLexer } from './lexer.js';
 import { getHover } from './hover.js';
 import type { HoverResult } from './hover.js';
 import type { IToken } from 'chevrotain';
+import type { SynthDefMetadata } from './completions.js';
+
+const TEST_METADATA: SynthDefMetadata = {
+	kick: {
+		specs: {
+			amp: { default: 0.1, min: 0, max: 1, unit: 'amp', curve: 4 },
+			pan: { default: 0, min: -1, max: 1, unit: '', curve: 2 },
+			rel: { default: 0.2, min: 0.001, max: 4, unit: 'seconds', curve: 4 }
+		}
+	}
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -229,7 +240,45 @@ describe('getHover — unknown identifier', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. HoverResult shape
+// 6. ParamSigil hover
+// ---------------------------------------------------------------------------
+
+describe('getHover — ParamSigil tokens', () => {
+	it('returns hover for "amp token when metadata provided', () => {
+		const toks = tokens('"amp');
+		const result = getHover(toks[0], undefined, 'kick', TEST_METADATA);
+		expect(result).not.toBeNull();
+	});
+
+	it('"amp hover content mentions "amp"', () => {
+		const toks = tokens('"amp');
+		const result = getHover(toks[0], undefined, 'kick', TEST_METADATA) as HoverResult;
+		expect(result.contents).toContain('amp');
+	});
+
+	it('"amp hover content includes min, max, and default', () => {
+		const toks = tokens('"amp');
+		const result = getHover(toks[0], undefined, 'kick', TEST_METADATA) as HoverResult;
+		expect(result.contents).toContain('Default');
+		expect(result.contents).toContain('Min');
+		expect(result.contents).toContain('Max');
+	});
+
+	it('returns null for unknown param name', () => {
+		const toks = tokens('"unknownparam');
+		const result = getHover(toks[0], undefined, 'kick', TEST_METADATA);
+		expect(result).toBeNull();
+	});
+
+	it('returns null when no metadata provided', () => {
+		const toks = tokens('"amp');
+		const result = getHover(toks[0]);
+		expect(result).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 8. HoverResult shape
 // ---------------------------------------------------------------------------
 
 describe('HoverResult shape', () => {

--- a/src/lib/lang/hover.ts
+++ b/src/lib/lang/hover.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IToken } from 'chevrotain';
+import type { SynthDefMetadata } from './completions.js';
 
 export interface HoverResult {
 	/** Markdown string to display in the hover popup. */
@@ -479,6 +480,58 @@ const DECORATOR_DOCS: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// SynthDef parameter hover
+// ---------------------------------------------------------------------------
+
+/**
+ * Build hover content for a `"param` token (e.g. `"amp`).
+ *
+ * @param paramName - The parameter name (without the leading `"`).
+ * @param activeSynthDef - The SynthDef name in scope, if known.
+ * @param synthdefMetadata - Runtime SynthDef metadata.
+ */
+function getParamHover(
+	paramName: string,
+	activeSynthDef: string | undefined,
+	synthdefMetadata: SynthDefMetadata
+): HoverResult | null {
+	type SpecEntry = { default: number; min: number; max: number; unit: string; curve: number };
+	let spec: SpecEntry | undefined;
+	let defName: string | undefined;
+
+	if (activeSynthDef && activeSynthDef in synthdefMetadata) {
+		spec = synthdefMetadata[activeSynthDef].specs[paramName] as SpecEntry | undefined;
+		defName = activeSynthDef;
+	} else {
+		// Search all known SynthDefs for this param name
+		for (const [name, def] of Object.entries(synthdefMetadata)) {
+			if (paramName in def.specs) {
+				spec = def.specs[paramName] as SpecEntry;
+				defName = name;
+				break;
+			}
+		}
+	}
+
+	if (!spec) return null;
+
+	const lines = [
+		`**\`"${paramName}\`** — direct SynthDef argument${defName ? ` (\`${defName}\`)` : ''}.`,
+		'',
+		`| Property | Value |`,
+		`| -------- | ----- |`,
+		`| Default  | ${spec.default} |`,
+		`| Min      | ${spec.min} |`,
+		`| Max      | ${spec.max} |`,
+		spec.unit ? `| Unit     | ${spec.unit} |` : null
+	]
+		.filter(Boolean)
+		.join('\n');
+
+	return { contents: lines };
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -490,9 +543,24 @@ const DECORATOR_DOCS: Record<string, string> = {
  * @param prevTokenName - The tokenType.name of the immediately preceding token
  *   (used to resolve context-sensitive identifier meanings, e.g. modifier vs
  *   decorator key vs scale name).
+ * @param activeSynthDef - The SynthDef name currently in scope, used for
+ *   `"param` token hover.
+ * @param synthdefMetadata - Runtime SynthDef metadata (loaded via fetch). If not
+ *   provided, `"param` tokens return null.
  */
-export function getHover(token: IToken, prevTokenName?: string): HoverResult | null {
+export function getHover(
+	token: IToken,
+	prevTokenName?: string,
+	activeSynthDef?: string,
+	synthdefMetadata: SynthDefMetadata = {}
+): HoverResult | null {
 	const typeName = token.tokenType.name;
+
+	// ParamSigil tokens: `"amp`, `"pan`, etc. — show SynthDef parameter details.
+	if (typeName === 'ParamSigil') {
+		const paramName = token.image.slice(1); // strip leading `"`
+		return getParamHover(paramName, activeSynthDef, synthdefMetadata);
+	}
 
 	// Non-identifier tokens: direct lookup by type name
 	if (typeName !== 'Identifier') {

--- a/src/lib/lang/lexer.test.ts
+++ b/src/lib/lang/lexer.test.ts
@@ -33,7 +33,8 @@ import {
 	Sharp,
 	Flat,
 	Bang,
-	Percent
+	Percent,
+	ParamSigil
 } from './lexer.js';
 
 describe('FluxLexer', () => {
@@ -542,6 +543,59 @@ describe('Percent — wet/dry operator', () => {
 		expect(pctIdx).toBeGreaterThan(0);
 		expect(tokens[pctIdx - 1].tokenType).toBe(Integer);
 		expect(tokens[pctIdx - 1].image).toBe('70');
+	});
+});
+
+describe('ParamSigil — direct SynthDef argument access', () => {
+	it('tokenizes "amp as a single ParamSigil token', () => {
+		const { tokens, errors } = FluxLexer.tokenize('"amp');
+		expect(errors).toHaveLength(0);
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].tokenType).toBe(ParamSigil);
+		expect(tokens[0].image).toBe('"amp');
+	});
+
+	it('tokenizes "pan as ParamSigil', () => {
+		const { tokens, errors } = FluxLexer.tokenize('"pan');
+		expect(errors).toHaveLength(0);
+		expect(tokens[0].tokenType).toBe(ParamSigil);
+		expect(tokens[0].image).toBe('"pan');
+	});
+
+	it('tokenizes "my_param as ParamSigil (underscores allowed)', () => {
+		const { tokens, errors } = FluxLexer.tokenize('"my_param');
+		expect(errors).toHaveLength(0);
+		expect(tokens[0].tokenType).toBe(ParamSigil);
+		expect(tokens[0].image).toBe('"my_param');
+	});
+
+	it('"amp(0.5) tokenizes as ParamSigil + LParen + Float + RParen', () => {
+		const { tokens, errors } = FluxLexer.tokenize('"amp(0.5)');
+		expect(errors).toHaveLength(0);
+		expect(tokens[0].tokenType).toBe(ParamSigil);
+		expect(tokens[0].image).toBe('"amp');
+		expect(tokens[1].tokenType).toBe(LParen);
+		expect(tokens[2].tokenType).toBe(Float);
+		expect(tokens[3].tokenType).toBe(RParen);
+	});
+
+	it('chained params: "amp(0.5)"pan(-0.3) tokenizes as two ParamSigil tokens', () => {
+		const { tokens, errors } = FluxLexer.tokenize('"amp(0.5)"pan(-0.3)');
+		expect(errors).toHaveLength(0);
+		const paramTokens = tokens.filter((t) => t.tokenType === ParamSigil);
+		expect(paramTokens).toHaveLength(2);
+		expect(paramTokens[0].image).toBe('"amp');
+		expect(paramTokens[1].image).toBe('"pan');
+	});
+
+	it('double-quoted string with space is a lex error (not ParamSigil)', () => {
+		const { errors } = FluxLexer.tokenize('"moog"');
+		expect(errors.length).toBeGreaterThan(0);
+	});
+
+	it('" followed by space is a lex error', () => {
+		const { errors } = FluxLexer.tokenize('" amp');
+		expect(errors.length).toBeGreaterThan(0);
 	});
 });
 

--- a/src/lib/lang/lexer.ts
+++ b/src/lib/lang/lexer.ts
@@ -557,6 +557,22 @@ export const Symbol = createToken({
 	// Monaco scope: 'string'
 });
 
+/**
+ * ParamSigil — direct SynthDef argument access.
+ * `"identifier` — double-quote immediately followed by an identifier, no whitespace.
+ * Analogous to `\symbol`: the `"` and identifier form a single token.
+ *
+ * e.g. `"amp`, `"pan`, `"cutoff`
+ *
+ * Used as: `note [0 2 4]"amp(0.5)"pan(-0.3)`
+ * The value argument is parsed separately (LParen + generatorExpr + RParen).
+ */
+export const ParamSigil = createToken({
+	name: 'ParamSigil',
+	pattern: /"[a-zA-Z_][a-zA-Z0-9_]*/
+	// Monaco scope: 'property'
+});
+
 // ---------------------------------------------------------------------------
 // Whitespace (skipped)
 // ---------------------------------------------------------------------------
@@ -645,6 +661,7 @@ export const allTokens = [
 	Float,
 	Integer,
 	Symbol,
+	ParamSigil,
 	// Whitespace — always last
 	WhiteSpace
 ];

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -634,6 +634,40 @@ describe('generator naming — unnamed patterns are errors', () => {
 	});
 });
 
+describe('"param — direct SynthDef argument access', () => {
+	it('parses note with single param: note lead [0 2 4]"amp(0.5)', () => {
+		expect(parse('note lead [0 2 4]"amp(0.5)').parseErrors).toHaveLength(0);
+	});
+
+	it('parses chained params: note lead [0 2 4]"amp(0.5)"pan(-0.3)', () => {
+		expect(parse('note lead [0 2 4]"amp(0.5)"pan(-0.3)').parseErrors).toHaveLength(0);
+	});
+
+	it('parses param with stochastic value: note lead [0 2 4]"amp(0.3rand0.8)', () => {
+		expect(parse('note lead [0 2 4]"amp(0.3rand0.8)').parseErrors).toHaveLength(0);
+	});
+
+	it('parses param with locked value: note lead [0 2 4]"amp(0.3rand0.8\'lock)', () => {
+		expect(parse('note lead [0 2 4]"amp(0.3rand0.8\'lock)').parseErrors).toHaveLength(0);
+	});
+
+	it('parses param with eager value: note lead [0 2 4]"amp(0.3rand0.8\'eager(4))', () => {
+		expect(parse('note lead [0 2 4]"amp(0.3rand0.8\'eager(4))').parseErrors).toHaveLength(0);
+	});
+
+	it('parses param on fx node: note lead [0 2 4] | fx(\\lpf)"cutoff(800)"rq(0.3)', () => {
+		expect(parse('note lead [0 2 4] | fx(\\lpf)"cutoff(800)"rq(0.3)').parseErrors).toHaveLength(0);
+	});
+
+	it('parses param mixed with modifiers: note lead [0 2 4]\'legato(0.8)"amp(0.5)', () => {
+		expect(parse('note lead [0 2 4]\'legato(0.8)"amp(0.5)').parseErrors).toHaveLength(0);
+	});
+
+	it('errors on bare "amp with no preceding expression', () => {
+		expect(parse('"amp(0.5)').parseErrors.length).toBeGreaterThan(0);
+	});
+});
+
 describe('derived generators — child:parent syntax', () => {
 	it("parses derived generator: sample perc:drums 'at(1/8)", () => {
 		expect(parse("sample perc:drums 'at(1/8)").parseErrors).toHaveLength(0);

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -79,6 +79,7 @@ import {
 	Rest,
 	Colon,
 	Percent,
+	ParamSigil,
 	INDENT,
 	DEDENT
 } from './lexer.js';
@@ -291,7 +292,10 @@ class FluxParser extends CstParser {
 			}
 		]);
 		this.MANY(() => {
-			this.SUBRULE(this.modifierSuffix);
+			this.OR3([
+				{ ALT: () => this.SUBRULE(this.modifierSuffix) },
+				{ ALT: () => this.SUBRULE(this.paramSuffix) }
+			]);
 		});
 		this.OPTION2(() => {
 			this.SUBRULE(this.transposition);
@@ -521,15 +525,18 @@ class FluxParser extends CstParser {
 	});
 
 	fxExpr = this.RULE('fxExpr', () => {
-		// fx(\lpf)'cutoff(1200) 70%
-		// \symbol names the FX SynthDef; optional modifiers set params;
+		// fx(\lpf)'cutoff(1200)"rq(0.3) 70%
+		// \symbol names the FX SynthDef; optional modifiers and/or params set args;
 		// optional Integer Percent at the end sets wet/dry level (default 100% wet).
 		this.CONSUME(Fx);
 		this.CONSUME(LParen);
 		this.CONSUME(Symbol);
 		this.CONSUME(RParen);
 		this.MANY(() => {
-			this.SUBRULE(this.modifierSuffix);
+			this.OR([
+				{ ALT: () => this.SUBRULE(this.modifierSuffix) },
+				{ ALT: () => this.SUBRULE(this.paramSuffix) }
+			]);
 		});
 		this.OPTION(() => {
 			this.CONSUME(Integer);
@@ -839,6 +846,16 @@ class FluxParser extends CstParser {
 		this.SUBRULE(this.numericLiteral); // last
 		this.CONSUME(LenSep); // 'x' separator
 		this.SUBRULE2(this.numericLiteral); // length
+	});
+
+	paramSuffix = this.RULE('paramSuffix', () => {
+		// `"paramName(generatorExpr)` — direct SynthDef argument access.
+		// ParamSigil is a single token: `"` immediately followed by the identifier.
+		// The value argument is mandatory (unlike modifiers where bare form is valid).
+		this.CONSUME(ParamSigil);
+		this.CONSUME(LParen);
+		this.SUBRULE(this.generatorExpr);
+		this.CONSUME(RParen);
 	});
 
 	constructor() {

--- a/synthdefs/kick.scd
+++ b/synthdefs/kick.scd
@@ -1,3 +1,4 @@
+
 k = SynthDef(\kick, {
     arg pan = 0, amp = 0.2, out = 0, rel = 0.2, cutoff = 8000,
     clickFreq = 500, clickRq = 0.4, clickAmp = 0.5, bodyDelay = 0.005,
@@ -19,6 +20,11 @@ metadata: (
 	credit: "Anders Eskildsen",
 	category: \percussion,
 	tags: [\kick, \percussive, \drum],
+	specs: Dictionary.newFrom([
+		\pan, ControlSpec(-1, 1, 2, 0.0, 0, ""),
+		\amp, ControlSpec(0, 1, 4, 0, 0.1, "amp"),
+		\rel, ControlSpec(0.001, 4, 4, 0, 0.2, "seconds"),
+	]),
     description: "A simple kick drum synthesizer. It combines a clicky noise component with a pitched sine wave body, both shaped by their own envelopes. The parameters allow for tweaking the attack, decay, and tonal characteristics of the kick.",
 	url: "https://sc.anderseskildsen.eu/05/a-kick/#sammenstning-til-synthdef"
 )


### PR DESCRIPTION
Closes #8

## Summary

- **Spec**: Add "Three syntactic roles" section (`@`/`'`/`"` boundary table); add `"param` subsection with token form, chaining, value expressions, and SynthDef metadata shape; consolidate the old decorator/modifier boundary note
- **Truth tables**: Add table #18 for `"param`
- **Lexer**: `ParamSigil` token — `"identifier` as a single token, analogous to `\symbol`
- **Parser**: `paramSuffix` rule — `"param(value)` valid wherever modifiers are valid, including on FX nodes
- **Highlighter**: `ParamSigil` → `tok-param` class (visually distinct from `'` and `\`)
- **Completions**: `"` trigger offers SynthDef param names from runtime metadata (passed by caller, not statically imported — matches the `fetch` pattern in `+page.ts`)
- **Hover**: `"param` tokens show min/max/default/unit table from runtime metadata
- **SynthDef source**: Add `specs` to `kick.scd`; update `compile_synthdefs.scd` to normalise specs into the JSON output
- Filed #14 for wiring `"param` values through to the scheduler callback (prerequisite for `note(\kick)` producing sound)

Generated with [Claude Code](https://claude.com/claude-code)