### PR TITLE
feat(dispatch): wire cycleOffset / 'at through gen() scheduler (#20)

### DIFF
--- a/src/lib/dispatch.test.ts
+++ b/src/lib/dispatch.test.ts
@@ -164,7 +164,7 @@ describe('eventBeatPosition', () => {
 		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 0 }, 1, 100, CB)).toBeCloseTo(100 + CB);
 	});
 
-	// cycleOffset set: anchors from startBeat, ignores cycleNumber
+	// cycleOffset shifts the anchor relative to cycleNumber (total offset = cycleNumber + cycleOffset)
 	it("'at(1/4): cycleOffset=0.25, cycleNumber=0, beatOffset=0 → startBeat + 0.25*CB", () => {
 		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 0.25 }, 0, 100, CB)).toBeCloseTo(
 			100 + 0.25 * CB
@@ -211,6 +211,41 @@ describe('eventBeatPosition', () => {
 	it("'at(-1/4): cycleOffset=-0.25, cycleNumber=0 → startBeat - 0.25*CB", () => {
 		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: -0.25 }, 0, 100, CB)).toBeCloseTo(
 			100 - 0.25 * CB
+		);
+	});
+
+	// beatOffset > 1 (event extends beyond current cycle boundary)
+	it('beatOffset=1.5 extends 1.5 cycles past startBeat', () => {
+		expect(eventBeatPosition({ beatOffset: 1.5 }, 0, 0, CB)).toBeCloseTo(1.5 * CB);
+	});
+
+	// Large cycleNumber — no float precision surprises
+	it('large cycleNumber produces correct absolute beat', () => {
+		expect(eventBeatPosition({ beatOffset: 0 }, 10000, 0, CB)).toBeCloseTo(10000 * CB);
+	});
+
+	// Input validation
+	it('throws for CYCLE_BEATS = 0', () => {
+		expect(() => eventBeatPosition({ beatOffset: 0 }, 0, 0, 0)).toThrow(
+			'eventBeatPosition: invalid CYCLE_BEATS 0'
+		);
+	});
+
+	it('throws for negative CYCLE_BEATS', () => {
+		expect(() => eventBeatPosition({ beatOffset: 0 }, 0, 0, -4)).toThrow(
+			'eventBeatPosition: invalid CYCLE_BEATS -4'
+		);
+	});
+
+	it('throws for non-finite CYCLE_BEATS', () => {
+		expect(() => eventBeatPosition({ beatOffset: 0 }, 0, 0, Infinity)).toThrow(
+			'eventBeatPosition: invalid CYCLE_BEATS Infinity'
+		);
+	});
+
+	it('throws for NaN beatOffset', () => {
+		expect(() => eventBeatPosition({ beatOffset: NaN }, 0, 0, CB)).toThrow(
+			'eventBeatPosition: beatOffset is not finite'
 		);
 	});
 });

--- a/src/lib/dispatch.test.ts
+++ b/src/lib/dispatch.test.ts
@@ -1,13 +1,14 @@
 /**
- * Tests for pure dispatch helpers (issue #18).
+ * Tests for pure dispatch helpers (issue #18, #20).
  *
  * Covers:
  *  - noteToFreq: MIDI note → Hz, with and without cent offset
  *  - buildOscParams: param priority (synthdef defaults < ev.params < freq)
+ *  - eventBeatPosition: absolute beat position for cycleOffset / 'at wiring
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { noteToFreq, buildOscParams } from './dispatch.js';
+import { noteToFreq, buildOscParams, eventBeatPosition } from './dispatch.js';
 
 // ---------------------------------------------------------------------------
 // noteToFreq
@@ -129,5 +130,87 @@ describe('buildOscParams', () => {
 
 	it('throws for Infinity note', () => {
 		expect(() => buildOscParams({ note: Infinity }, undefined)).toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// eventBeatPosition (issue #20 — cycleOffset / 'at wiring)
+// ---------------------------------------------------------------------------
+
+describe('eventBeatPosition', () => {
+	const CB = 4; // CYCLE_BEATS
+
+	// No cycleOffset: position is cycleNumber + beatOffset, scaled by CYCLE_BEATS
+	it('no cycleOffset, cycleNumber=0, beatOffset=0 → startBeat', () => {
+		expect(eventBeatPosition({ beatOffset: 0 }, 0, 100, CB)).toBeCloseTo(100);
+	});
+
+	it('no cycleOffset, cycleNumber=0, beatOffset=0.5 → startBeat + 0.5*CB', () => {
+		expect(eventBeatPosition({ beatOffset: 0.5 }, 0, 100, CB)).toBeCloseTo(100 + 0.5 * CB);
+	});
+
+	it('no cycleOffset, cycleNumber=1, beatOffset=0 → startBeat + 1*CB', () => {
+		expect(eventBeatPosition({ beatOffset: 0 }, 1, 100, CB)).toBeCloseTo(100 + CB);
+	});
+
+	it('no cycleOffset, cycleNumber=2, beatOffset=0.25 → startBeat + 2*CB + 0.25*CB', () => {
+		expect(eventBeatPosition({ beatOffset: 0.25 }, 2, 100, CB)).toBeCloseTo(
+			100 + 2 * CB + 0.25 * CB
+		);
+	});
+
+	// cycleOffset=0: same as no cycleOffset (cycleNumber still applied)
+	it('cycleOffset=0, cycleNumber=1, beatOffset=0 → startBeat + 1*CB', () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 0 }, 1, 100, CB)).toBeCloseTo(100 + CB);
+	});
+
+	// cycleOffset set: anchors from startBeat, ignores cycleNumber
+	it("'at(1/4): cycleOffset=0.25, cycleNumber=0, beatOffset=0 → startBeat + 0.25*CB", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 0.25 }, 0, 100, CB)).toBeCloseTo(
+			100 + 0.25 * CB
+		);
+	});
+
+	it("'at(1/4): cycleOffset=0.25, cycleNumber=0, beatOffset=1/3 → startBeat + 0.25*CB + (1/3)*CB", () => {
+		expect(eventBeatPosition({ beatOffset: 1 / 3, cycleOffset: 0.25 }, 0, 100, CB)).toBeCloseTo(
+			100 + 0.25 * CB + (1 / 3) * CB
+		);
+	});
+
+	it("'at(1) shifts pattern one full cycle: cycleOffset=1 → startBeat + 1*CB", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 1 }, 0, 100, CB)).toBeCloseTo(100 + CB);
+	});
+
+	// Finite pattern 'n(3): events emitted in cycleNumber=0 with cycleOffset=0,1,2
+	it("'n(3) rep 0: cycleOffset=0, cycleNumber=0 → startBeat", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 0 }, 0, 0, CB)).toBeCloseTo(0);
+	});
+
+	it("'n(3) rep 1: cycleOffset=1, cycleNumber=0 → startBeat + CB", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 1 }, 0, 0, CB)).toBeCloseTo(CB);
+	});
+
+	it("'n(3) rep 2: cycleOffset=2, cycleNumber=0 → startBeat + 2*CB", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 2 }, 0, 0, CB)).toBeCloseTo(2 * CB);
+	});
+
+	// Looping with 'at(0.25): cycleOffset stays 0.25 each cycle; cycleNumber provides the integer part
+	it("looping 'at(0.25), cycleNumber=1 → startBeat + (1+0.25)*CB", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 0.25 }, 1, 0, CB)).toBeCloseTo(
+			1.25 * CB
+		);
+	});
+
+	it("looping 'at(0.25), cycleNumber=2 → startBeat + (2+0.25)*CB", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: 0.25 }, 2, 0, CB)).toBeCloseTo(
+			2.25 * CB
+		);
+	});
+
+	// Negative cycleOffset 'at(-1/4)
+	it("'at(-1/4): cycleOffset=-0.25, cycleNumber=0 → startBeat - 0.25*CB", () => {
+		expect(eventBeatPosition({ beatOffset: 0, cycleOffset: -0.25 }, 0, 100, CB)).toBeCloseTo(
+			100 - 0.25 * CB
+		);
 	});
 });

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -34,19 +34,22 @@ export function noteToFreq(note: number, cent?: number): number {
 /**
  * Compute the absolute beat position of a scheduled event.
  *
- * Events without `cycleOffset` (looping, no 'at) are positioned relative to
- * the cycle they come from: startBeat + cycleNumber * CYCLE_BEATS + beatOffset * CYCLE_BEATS.
+ * Formula: startBeat + (cycleNumber + cycleOffset) * CYCLE_BEATS + beatOffset * CYCLE_BEATS
  *
- * Events with `cycleOffset` (from 'at or finite 'n repetitions) are anchored
- * from startBeat using the formula from the issue spec:
- *   startBeat + (cycleNumber + cycleOffset) * CYCLE_BEATS + beatOffset * CYCLE_BEATS
+ * Both cycleNumber and cycleOffset always contribute — cycleOffset shifts the
+ * anchor relative to cycleNumber (total cycle offset = cycleNumber + cycleOffset).
  *
- * For looping patterns with 'at(X), the evaluator always emits cycleOffset=X and
- * cycleNumber increments each cycle — so the full offset is (cycleNumber + X).
+ * For looping patterns with 'at(X), the evaluator emits cycleOffset=X each cycle
+ * and increments cycleNumber — so the event lands at (cycleNumber + X) cycles from
+ * startBeat.
  *
  * For finite patterns 'n(N), the evaluator emits all repetitions in cycleNumber=0
- * with cycleOffset=0,1,...,N-1 — so cycleNumber contributes 0 and cycleOffset provides
+ * with cycleOffset=0,1,...,N-1. cycleNumber contributes 0 and cycleOffset provides
  * the integer rep offset.
+ * (Evaluator contract — see createInstance / 'n handling.)
+ *
+ * Throws if CYCLE_BEATS is not a positive finite number, or if beatOffset is not
+ * finite, to match the validation pattern in buildOscParams.
  */
 export function eventBeatPosition(
 	ev: Pick<ScheduledEvent, 'beatOffset' | 'cycleOffset'>,
@@ -54,6 +57,12 @@ export function eventBeatPosition(
 	startBeat: number,
 	CYCLE_BEATS: number
 ): number {
+	if (!Number.isFinite(CYCLE_BEATS) || CYCLE_BEATS <= 0) {
+		throw new Error(`eventBeatPosition: invalid CYCLE_BEATS ${CYCLE_BEATS}`);
+	}
+	if (!Number.isFinite(ev.beatOffset)) {
+		throw new Error(`eventBeatPosition: beatOffset is not finite: ${ev.beatOffset}`);
+	}
 	const cycleOff = ev.cycleOffset ?? 0;
 	return startBeat + (cycleNumber + cycleOff) * CYCLE_BEATS + ev.beatOffset * CYCLE_BEATS;
 }

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -32,6 +32,33 @@ export function noteToFreq(note: number, cent?: number): number {
 }
 
 /**
+ * Compute the absolute beat position of a scheduled event.
+ *
+ * Events without `cycleOffset` (looping, no 'at) are positioned relative to
+ * the cycle they come from: startBeat + cycleNumber * CYCLE_BEATS + beatOffset * CYCLE_BEATS.
+ *
+ * Events with `cycleOffset` (from 'at or finite 'n repetitions) are anchored
+ * from startBeat using the formula from the issue spec:
+ *   startBeat + (cycleNumber + cycleOffset) * CYCLE_BEATS + beatOffset * CYCLE_BEATS
+ *
+ * For looping patterns with 'at(X), the evaluator always emits cycleOffset=X and
+ * cycleNumber increments each cycle — so the full offset is (cycleNumber + X).
+ *
+ * For finite patterns 'n(N), the evaluator emits all repetitions in cycleNumber=0
+ * with cycleOffset=0,1,...,N-1 — so cycleNumber contributes 0 and cycleOffset provides
+ * the integer rep offset.
+ */
+export function eventBeatPosition(
+	ev: Pick<ScheduledEvent, 'beatOffset' | 'cycleOffset'>,
+	cycleNumber: number,
+	startBeat: number,
+	CYCLE_BEATS: number
+): number {
+	const cycleOff = ev.cycleOffset ?? 0;
+	return startBeat + (cycleNumber + cycleOff) * CYCLE_BEATS + ev.beatOffset * CYCLE_BEATS;
+}
+
+/**
  * Build the OSC parameter object for a note event.
  *
  * Priority (lowest → highest):

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -282,15 +282,23 @@
 		//
 		// Beat positions are computed as absolute offsets from nextCycleBeat using
 		// eventBeatPosition(), which handles cycleOffset ('at / finite 'n repetitions).
-		// schedulerBeat mirrors the scheduler's internal nextBeat cursor so we can
-		// compute gaps correctly when cycleOffset anchors events away from the cursor.
+		// schedulerBeat is the generator's local accounting cursor — it tracks where
+		// the last yielded event landed so gap durations can be computed correctly
+		// when cycleOffset anchors events away from the natural cycle start.
 		function* gen(): Generator<GenEvent> {
 			let cycleIdx = 0;
 			let schedulerBeat = nextCycleBeat;
 			while (true) {
 				const result = inst.evaluate({ cycleNumber: cycleIdx });
-				if (!result.ok) return;
-				if (result.done) return;
+				if (!result.ok) {
+					appendLog(`Pattern error in cycle ${cycleIdx}: ${result.error}`, 'error');
+					console.error('[gen] evaluate() failed:', result.error);
+					return;
+				}
+				if (result.done) {
+					appendLog('Pattern finished', 'info');
+					return;
+				}
 				// Sort by absolute beat position so events from multiple loops are
 				// interleaved correctly, including cycleOffset-shifted events.
 				const events = result.events
@@ -303,8 +311,17 @@
 				for (let i = 0; i < events.length; i++) {
 					const ev = events[i];
 					const targetBeat = eventBeatPosition(ev, cycleIdx, nextCycleBeat, CYCLE_BEATS);
-					const gap = Math.max(0, targetBeat - schedulerBeat);
-					schedulerBeat = targetBeat;
+					const rawGap = targetBeat - schedulerBeat;
+					if (rawGap < 0) {
+						console.warn(
+							`[gen] Event at beat ${targetBeat} is behind scheduler cursor ${schedulerBeat} ` +
+								`(gap ${rawGap.toFixed(4)}). cycleOffset=${ev.cycleOffset ?? 0}, ` +
+								`beatOffset=${ev.beatOffset}. Clamping to 0 — timing may be incorrect.`
+						);
+					}
+					const gap = Math.max(0, rawGap);
+					// Only advance the cursor — never move it backward on a clamped event.
+					schedulerBeat = Math.max(schedulerBeat, targetBeat);
 
 					if (ev.type === 'fx' || ev.type === 'rest') {
 						// FX routing not yet wired. Rest slots advance the clock but produce no sound.
@@ -315,15 +332,23 @@
 					const gateDurationSeconds = clock.beatsToSeconds(ev.duration * CYCLE_BEATS);
 					yield { skip: false, ev, duration: gap, gateDurationSeconds };
 				}
-				// Advance scheduler to the start of the next cycle boundary before
-				// evaluating the next cycle. This ensures the cursor is always aligned
-				// to a cycle edge regardless of where the last event landed.
+				// Fill any remaining gap to the cycle boundary so cycleIdx always
+				// advances from a clean cycle edge. For events that land exactly on or
+				// past the boundary (cycleEndGap <= 0), skip the yield but always snap
+				// the cursor so it never drifts into the next cycle.
 				const nextCycleBoundary = nextCycleBeat + (cycleIdx + 1) * CYCLE_BEATS;
 				const cycleEndGap = nextCycleBoundary - schedulerBeat;
+				if (cycleEndGap < 0) {
+					console.warn(
+						`[gen] Cycle ${cycleIdx} overshot its boundary by ${(-cycleEndGap).toFixed(4)} beats ` +
+							`(schedulerBeat=${schedulerBeat}, boundary=${nextCycleBoundary}). ` +
+							`Snapping cursor to prevent cumulative drift.`
+					);
+				}
 				if (cycleEndGap > 0) {
 					yield { duration: cycleEndGap, skip: true };
-					schedulerBeat = nextCycleBoundary;
 				}
+				schedulerBeat = nextCycleBoundary;
 				cycleIdx++;
 			}
 		}
@@ -360,7 +385,8 @@
 				}
 			},
 			CYCLE_BEATS,
-			nextCycleBeat
+			nextCycleBeat,
+			(msg) => appendLog(`Scheduler error: ${msg}`, 'error')
 		);
 
 		appendLog('playing loop', 'info');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
 	import { boot, serverState, getServer, getInstance } from 'svelte-supersonic';
 	import { run, sc as scProxy, clock, type SchedulerHandle } from '$lib/scheduler';
 	import { createInstance } from '$lib/lang/evaluator';
-	import { buildOscParams } from '$lib/dispatch';
+	import { buildOscParams, eventBeatPosition } from '$lib/dispatch';
 	import FluxEditor from '$lib/FluxEditor.svelte';
 	import SiteHeader from '$lib/SiteHeader.svelte';
 	import SynthDefPanel from '$lib/SynthDefPanel.svelte';
@@ -279,20 +279,32 @@
 
 		// Yield one entry per scheduled event; `duration` is the gap to the next
 		// event (drives scheduler advancement).
+		//
+		// Beat positions are computed as absolute offsets from nextCycleBeat using
+		// eventBeatPosition(), which handles cycleOffset ('at / finite 'n repetitions).
+		// schedulerBeat mirrors the scheduler's internal nextBeat cursor so we can
+		// compute gaps correctly when cycleOffset anchors events away from the cursor.
 		function* gen(): Generator<GenEvent> {
-			let cycleNumber = 0;
+			let cycleIdx = 0;
+			let schedulerBeat = nextCycleBeat;
 			while (true) {
-				const result = inst.evaluate({ cycleNumber: cycleNumber++ });
+				const result = inst.evaluate({ cycleNumber: cycleIdx });
 				if (!result.ok) return;
 				if (result.done) return;
-				// Sort by beatOffset so events from multiple loops are interleaved
-				// correctly — without this, a negative gap causes all remaining events
-				// to collapse to the same NTP time.
-				const events = result.events.slice().sort((a, b) => a.beatOffset - b.beatOffset);
+				// Sort by absolute beat position so events from multiple loops are
+				// interleaved correctly, including cycleOffset-shifted events.
+				const events = result.events
+					.slice()
+					.sort(
+						(a, b) =>
+							eventBeatPosition(a, cycleIdx, nextCycleBeat, CYCLE_BEATS) -
+							eventBeatPosition(b, cycleIdx, nextCycleBeat, CYCLE_BEATS)
+					);
 				for (let i = 0; i < events.length; i++) {
 					const ev = events[i];
-					const nextBeatOffset = i + 1 < events.length ? events[i + 1].beatOffset : 1; // 1 = end of cycle
-					const gap = (nextBeatOffset - ev.beatOffset) * CYCLE_BEATS;
+					const targetBeat = eventBeatPosition(ev, cycleIdx, nextCycleBeat, CYCLE_BEATS);
+					const gap = Math.max(0, targetBeat - schedulerBeat);
+					schedulerBeat = targetBeat;
 
 					if (ev.type === 'fx' || ev.type === 'rest') {
 						// FX routing not yet wired. Rest slots advance the clock but produce no sound.
@@ -303,6 +315,16 @@
 					const gateDurationSeconds = clock.beatsToSeconds(ev.duration * CYCLE_BEATS);
 					yield { skip: false, ev, duration: gap, gateDurationSeconds };
 				}
+				// Advance scheduler to the start of the next cycle boundary before
+				// evaluating the next cycle. This ensures the cursor is always aligned
+				// to a cycle edge regardless of where the last event landed.
+				const nextCycleBoundary = nextCycleBeat + (cycleIdx + 1) * CYCLE_BEATS;
+				const cycleEndGap = nextCycleBoundary - schedulerBeat;
+				if (cycleEndGap > 0) {
+					yield { duration: cycleEndGap, skip: true };
+					schedulerBeat = nextCycleBoundary;
+				}
+				cycleIdx++;
 			}
 		}
 


### PR DESCRIPTION
Closes #20

## Summary
- Add `eventBeatPosition()` pure helper to `dispatch.ts` — computes absolute beat position as `startBeat + (cycleNumber + cycleOffset) * CYCLE_BEATS + beatOffset * CYCLE_BEATS`
- Rewrite `gen()` in `+page.svelte` to track `schedulerBeat` and use `eventBeatPosition()` for all events, so `'at` phase offsets and finite `'n` repetitions land at the correct absolute beat positions
- Sort events within each cycle by absolute beat position (not just `beatOffset`) to handle cycleOffset-shifted events correctly
- 14 new unit tests covering baseline looping, `'at` phase shift, finite `'n(3)` repetitions, and negative `'at`

Generated with [Claude Code](https://claude.com/claude-code)