### PR TITLE
feat(lang): collapse 'pick and 'wran into unified 'pick (#25)

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -33,18 +33,24 @@ Inside `[...]` sequence generators, elements are separated by spaces. Commas are
 
 ### Sequence generators
 
-> _See truth tables [4 (Weighted random / `'wran`)](DSL-truthtables.md#4-weighted-random-wran-truth-table)._
+> _See truth table [4 (Weighted random / `'pick`)](DSL-truthtables.md#4-weighted-random-pick-truth-table)._
 
 `[...]` is the fundamental generator type. By default it yields its elements in order, cycling back to the start. Modifiers change the traversal strategy:
 
 ```flux
-[1 2 3]         // yields 1, 2, 3, 1, 2, 3, ... — like Pseq([1, 2, 3])
-[1 2 3]'shuf    // shuffle then traverse, like Pshuf
-[1 2 3]'pick    // pick a random element each time, like Prand
-[1 2 3?2]'wran  // pick stochastically, like Pwrand
+[1 2 3]            // yields 1, 2, 3, 1, 2, 3, ... — like Pseq([1, 2, 3])
+[1 2 3]'shuf       // shuffle then traverse, like Pshuf
+[1 2 3]'pick       // uniform random element each time, like Prand
+[1 2?2 3]'pick     // weighted random — like Pwrand with weights 1/2/1
 ```
 
-Specifically for `'wran`: weight for each element is 1 by default. The weight can be overridden with the `?` operator. The `?` weight syntax is only meaningful when `'wran` is present — using `?` without `'wran` is a semantic error.
+`'pick` supports optional per-element weights via the `?` operator. Unweighted elements default to weight 1; when no weights are present, `'pick` is uniform random. When any weights are present, selection is proportional to the weights (normalised to sum to 1).
+
+- `?n` — `n` must be a non-negative numeric literal (integer or float). `?0` means the element is never picked.
+- If every element has weight 0, the slot is silent (rest event), the same as `_`.
+- Negative weights (e.g. `?-1`) are a parse error.
+- Generator expressions are not valid as weights — `?` must be followed by a numeric literal.
+- The `?` weight syntax is only meaningful on a list whose own modifiers include `'pick`. Using `?` on a list without `'pick` is not an error, but the weight is ignored and a warning is logged. This rule applies per list level: `[[1 2?3]'pick 5]` is fine, but `[[1 2?3] 5]'pick` ignores the inner `?3` because the inner list has no `'pick`.
 
 ### Rests
 

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -73,25 +73,27 @@ How stutter counts are sampled. Applies to all content types.
 
 ---
 
-# 4. **Weighted Random `'wran` Truth Table**
+# 4. **Weighted Random `'pick` Truth Table**
 
-How weights are interpreted.
+How `?` weights on a `'pick` list are interpreted.
 
-| Code                  | Interpretation        | Evaluation                 | Result                           |
-| --------------------- | --------------------- | -------------------------- | -------------------------------- |
-| `[1 2 3]'wran`        | All weights = 1.      | Normalize equal weights.   | Uniform random.                  |
-| `[1?3 2?1]'wran`      | Explicit weights.     | Weighted selection.        | 1 appears 3× as often as 2.      |
-| `[x?0 y?1]'wran`      | Zero weight.          | Remove entry entirely.     | y only.                          |
-| `[a?(1rand3)'lock b]` | Dynamic weight for a. | Lock weight at first eval. | Weight fixed for entire session. |
+| Code               | Interpretation                      | Evaluation                                    | Result                          |
+| ------------------ | ----------------------------------- | --------------------------------------------- | ------------------------------- |
+| `[1 2 3]'pick`     | No weights.                         | All weights default to 1; uniform random.     | Uniform random.                 |
+| `[1 2?2 3]'pick`   | Mixed explicit and default weights. | Weights 1/2/1 → probs 0.25/0.5/0.25.          | 2 appears half the time.        |
+| `[1?3 2?1]'pick`   | Explicit weights.                   | Weighted selection.                           | 1 appears 3× as often as 2.     |
+| `[x?0 y?1]'pick`   | Zero weight.                        | x is never picked.                            | y only.                         |
+| `[x?0 y?0]'pick`   | All weights zero.                   | No element can be selected; emit rest.        | Silent slot (rest event).       |
+| `[[1 2?3]'pick 5]` | `?` on inner `'pick` list.          | Inner list picks 2 with weight 3, else 1.     | Valid per-level check.          |
+| `[[1 2?3] 5]'pick` | `?` on inner list without `'pick`.  | Inner `?3` ignored with warning; outer picks. | Warning logged; weight ignored. |
 
 **Error cases**
 
-| Code                              | Failure Type   | Why                                                                   |
-| --------------------------------- | -------------- | --------------------------------------------------------------------- |
-| `[a?invalid]`                     | Parse error    | Weight must be a numeric literal or generator, not a bare identifier. |
-| `[a?-1]`                          | Semantic error | Negative weight is not meaningful.                                    |
-| `[x?0 y?0]'wran`                  | Semantic error | All weights zero; no element can be selected.                         |
-| `[1 2]'pick` with `?` on elements | Semantic error | `?` weight syntax is only valid with `'wran`.                         |
+| Code                | Failure Type | Why                                                                       |
+| ------------------- | ------------ | ------------------------------------------------------------------------- |
+| `[a?invalid]`       | Parse error  | Weight must be a non-negative numeric literal.                            |
+| `[a?-1]'pick`       | Parse error  | Negative weights are not meaningful.                                      |
+| `[a?(1rand3)]'pick` | Parse error  | Generator expressions are not valid as weights; weight must be a literal. |
 
 ---
 

--- a/src/lib/lang/completions.ts
+++ b/src/lib/lang/completions.ts
@@ -137,15 +137,9 @@ const MODIFIER_COMPLETIONS: CompletionItem[] = [
 	{
 		label: 'pick',
 		insertText: 'pick',
-		detail: "'pick — random element each time",
-		documentation: 'Like Prand.',
-		kind: 'keyword'
-	},
-	{
-		label: 'wran',
-		insertText: 'wran',
-		detail: "'wran — weighted random selection",
-		documentation: 'Use ?weight on elements to assign relative weights.',
+		detail: "'pick — random element each time (optionally weighted)",
+		documentation:
+			'Uniform random by default. Use `?n` on elements to assign non-negative weights; unweighted elements default to 1. Like Prand / Pwrand.',
 		kind: 'keyword'
 	},
 	{

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -1084,10 +1084,10 @@ describe("'stut — stutter (truth table 3)", () => {
 	});
 });
 
-describe("'wran — weighted random pick (truth table 4)", () => {
-	it('uniform weights: all three values appear across many samples', () => {
+describe("'pick — random element selection (truth table 4)", () => {
+	it('unweighted: picks a random element each cycle (at least 2 distinct values over 50 cycles)', () => {
 		vi.spyOn(Math, 'random').mockRestore();
-		const i = inst("note x [0 2 4]'wran");
+		const i = inst("note x [0 2 4]'pick");
 		const seen = new Set<number>();
 		for (let c = 0; c < 50; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1097,10 +1097,11 @@ describe("'wran — weighted random pick (truth table 4)", () => {
 		expect(seen.size).toBeGreaterThanOrEqual(2);
 	});
 
-	it('element with weight 3 appears more often than element with weight 1', () => {
-		const i = inst("note x [0?3 4?1]'wran");
+	it('explicit weights: element with weight 3 appears more often than element with weight 1', () => {
+		vi.spyOn(Math, 'random').mockRestore();
+		const i = inst("note x [0?3 4?1]'pick");
 		const counts = { n0: 0, n4: 0 };
-		for (let c = 0; c < 100; c++) {
+		for (let c = 0; c < 200; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			if (!r.ok) throw new Error(r.error);
 			const note = (r.events[0] as any).note;
@@ -1110,8 +1111,28 @@ describe("'wran — weighted random pick (truth table 4)", () => {
 		expect(counts.n0).toBeGreaterThan(counts.n4);
 	});
 
-	it('zero weight removes element: only the non-zero-weight element appears', () => {
-		const i = inst("note x [0?0 4?1]'wran");
+	it('mixed weights: unweighted elements default to weight 1 ([1 2?2 3]pick)', () => {
+		vi.spyOn(Math, 'random').mockRestore();
+		// Expected probs 0.25 / 0.5 / 0.25
+		const i = inst("note x [0 2?2 4]'pick");
+		const counts = { n0: 0, n2: 0, n4: 0 };
+		for (let c = 0; c < 400; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			for (const e of r.events) {
+				const note = (e as any).note;
+				if (note === 60) counts.n0++;
+				else if (note === 64) counts.n2++;
+				else if (note === 67) counts.n4++;
+			}
+		}
+		// 2 (the double-weighted one) should dominate
+		expect(counts.n2).toBeGreaterThan(counts.n0);
+		expect(counts.n2).toBeGreaterThan(counts.n4);
+	});
+
+	it('zero weight: element is never picked', () => {
+		const i = inst("note x [0?0 4?1]'pick");
 		const seen = new Set<number>();
 		for (let c = 0; c < 20; c++) {
 			const r = i.evaluate({ cycleNumber: c });
@@ -1121,18 +1142,46 @@ describe("'wran — weighted random pick (truth table 4)", () => {
 		expect(seen.has(60)).toBe(false); // degree 0, weight 0
 		expect(seen.has(67)).toBe(true); // degree 4, weight 1
 	});
-});
 
-describe("'pick — random element selection", () => {
-	it('picks a random element each cycle (at least 2 distinct values over 50 cycles)', () => {
-		const i = inst("note x [0 2 4]'pick");
-		const seen = new Set<number>();
-		for (let c = 0; c < 50; c++) {
+	it('all-zero weights: slots are silent (rest events)', () => {
+		const i = inst("note x [0?0 4?0]'pick");
+		for (let c = 0; c < 5; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			if (!r.ok) throw new Error(r.error);
-			r.events.forEach((e) => seen.add((e as any).note));
+			// All events should be rests — no note events
+			for (const e of r.events) {
+				expect(e.contentType).toBe('rest');
+			}
 		}
-		expect(seen.size).toBeGreaterThanOrEqual(2);
+	});
+
+	it('? without pick: weights ignored, list traverses sequentially', () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const evs = eval0('note x [0 2?5 4]');
+		// Sequence, not weighted — still emits all three in order
+		expect(evs.map((e) => (e as any).note)).toEqual([60, 64, 67]);
+		expect(warnSpy).toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+
+	it('? on inner list without pick: inner weight ignored; outer pick still works', () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		// Outer list picks from either the inner seq list or degree 5.
+		// Inner [0 2?3] has no 'pick, so the ?3 is ignored (warning).
+		const i = inst("note x [[0 2?3] 5]'pick");
+		for (let c = 0; c < 5; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+		}
+		expect(warnSpy).toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+
+	it("'wran is removed — silently ignored (falls back to seq traversal)", () => {
+		// 'wran is no longer a recognised traversal modifier. The list should
+		// traverse sequentially (default).
+		const evs = eval0("note x [0 2 4]'wran");
+		expect(evs.map((e) => (e as any).note)).toEqual([60, 64, 67]);
 	});
 });
 
@@ -1714,27 +1763,20 @@ describe("'n edge cases", () => {
 	});
 });
 
-describe("'wran edge cases", () => {
-	it('negative weight is clamped to 0 — only positive-weight element is selected', () => {
-		// [0?-1 1?1]'wran — weight for 0 clamped to 0, so only degree 1 ever fires
-		// Run 20 cycles to confirm degree 1 (D5=62) always wins
-		const i = inst("note x [0?-1 1?1]'wran");
-		for (let c = 0; c < 20; c++) {
-			const r = i.evaluate({ cycleNumber: c });
-			if (!r.ok) throw new Error(r.error);
-			// Exactly 2 slots drawn; both should be degree 1 (= MIDI 62)
-			for (const e of r.events) expect((e as any).note).toBe(62);
-		}
+describe("'pick weight edge cases", () => {
+	it('negative weights are rejected at parse time', () => {
+		const i = createInstance("note x [0?-1 1?1]'pick");
+		expect(i.ok).toBe(false);
 	});
 
-	it('all-zero weights fall back to first element', () => {
-		// Evaluator fallback: if total weight = 0, return elements[0]
-		const i = inst("note x [0?0 4?0]'wran");
-		for (let c = 0; c < 10; c++) {
+	it('all-zero weights produce only rest events', () => {
+		const i = inst("note x [0?0 4?0]'pick");
+		for (let c = 0; c < 5; c++) {
 			const r = i.evaluate({ cycleNumber: c });
 			if (!r.ok) throw new Error(r.error);
-			// Both slots pick elements[0] → degree 0 = C5 = MIDI 60
-			for (const e of r.events) expect((e as any).note).toBe(60);
+			for (const e of r.events) {
+				expect(e.contentType).toBe('rest');
+			}
 		}
 	});
 });

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -46,8 +46,7 @@
  * - 'stut(n): repeat each event n times; total events = N×k, each slot = 1/(N×k)
  * - 'maybe(p): pass each event with probability p; empty array is ok
  * - 'shuf: shuffle elements once per cycle, then traverse in order
- * - 'pick: pick a random element each slot
- * - 'wran: weighted random selection (uses ? weight syntax per element)
+ * - 'pick: random element each slot (with optional ? weights for weighted selection)
  * - 'legato(n): gate-close time = n × slot
  * - 'offset(ms): shift all event times by ms
  * - 'mono (via `mono` content type keyword): single synth node; events carry mono:true
@@ -497,7 +496,7 @@ type CompiledScalar = {
 	runner: RunnerState;
 	/** Accidental semitone offset (0 = none). Applied before scale lookup. */
 	accidentalOffset: number;
-	/** Per-element weight for 'wran (default: 1). */
+	/** Per-element weight for 'pick (default: 1). */
 	weight: RunnerState;
 	/**
 	 * Absolute beat offset from cycle start, set by the `@` timing syntax.
@@ -510,14 +509,14 @@ type CompiledSubsequence = {
 	kind: 'sequence';
 	elements: CompiledElement[];
 	traversal: TraversalMode;
-	/** Per-element weight for parent 'wran selection (default: 1). */
+	/** Per-element weight for parent 'pick selection (default: 1). */
 	weight: RunnerState;
 };
 
 /** A silent slot — occupies time but spawns no synth. */
 type CompiledRest = {
 	kind: 'rest';
-	/** Per-element weight for parent 'wran selection (default: 1). */
+	/** Per-element weight for parent 'pick selection (default: 1). */
 	weight: RunnerState;
 };
 
@@ -525,7 +524,7 @@ type CompiledRest = {
 type CompiledSymbol = {
 	kind: 'symbol';
 	name: string; // buffer name without leading \
-	/** Per-element weight for parent 'wran selection (default: 1). */
+	/** Per-element weight for parent 'pick selection (default: 1). */
 	weight: RunnerState;
 	beatOverride?: number;
 };
@@ -605,7 +604,9 @@ function compileElement(elem: CstNode, inherited: EagerMode): CompiledElement | 
 		let subTraversal: TraversalMode = 'seq';
 		if (hasModifier(subListMods, 'shuf')) subTraversal = 'shuf';
 		else if (hasModifier(subListMods, 'pick')) subTraversal = 'pick';
-		else if (hasModifier(subListMods, 'wran')) subTraversal = 'wran';
+		if (subTraversal !== 'pick' && listHasExplicitWeights(seqGen)) {
+			console.warn("[flux] `?` weight ignored: weights are only meaningful on lists with 'pick");
+		}
 		const subElemNodes = (seqGen.children.sequenceElement as CstNode[]) ?? [];
 		const subElements: CompiledElement[] = [];
 		for (const se of subElemNodes) {
@@ -629,27 +630,36 @@ function compileElement(elem: CstNode, inherited: EagerMode): CompiledElement | 
 	const poll = numGenToPollFn(numGen);
 	if (!poll) return null;
 
-	// Weight from ?expr syntax
-	let weight = makeRunner(() => 1, { kind: 'lock' });
-	const questionToks = (elem.children.Question as IToken[]) ?? [];
-	if (questionToks.length > 0) {
-		// Weight is either a numericLiteral child or a generatorExpr child (in parens)
-		const weightLit = ((elem.children.numericLiteral as CstNode[]) ?? [])[0];
-		const weightGenExpr = ((elem.children.generatorExpr as CstNode[]) ?? [])[1]; // second generatorExpr
-		if (weightLit) {
-			const w = litToNumber(weightLit) ?? 1;
-			weight = makeRunner(() => w, { kind: 'lock' });
-		} else if (weightGenExpr) {
-			const wAtomic = ((weightGenExpr.children.atomicGenerator as CstNode[]) ?? [])[0];
-			const wNumGen = wAtomic ? ((wAtomic.children.numericGenerator as CstNode[]) ?? [])[0] : null;
-			const wPoll = wNumGen ? numGenToPollFn(wNumGen) : null;
-			const wMods = (weightGenExpr.children.modifierSuffix as CstNode[]) ?? [];
-			const wMode = extractEagerMode(wMods) ?? { kind: 'lock' };
-			if (wPoll) weight = makeRunner(wPoll, wMode);
-		}
-	}
+	// Weight from `?n` suffix. `n` must be a non-negative numeric literal,
+	// enforced by the parser's `weightLiteral` rule (no Minus, no generator).
+	const weight = weightFromElem(elem);
 
 	return { kind: 'scalar', runner: makeRunner(poll, effectiveMode), accidentalOffset, weight };
+}
+
+/**
+ * Extract the `?n` weight from a sequenceElement CST node. Defaults to 1 when
+ * no `?` is present. `n` is guaranteed to be a non-negative numeric literal
+ * (the parser's `weightLiteral` rule rejects negatives and generator forms).
+ */
+function weightFromElem(elem: CstNode): RunnerState {
+	const questionToks = (elem.children.Question as IToken[]) ?? [];
+	if (questionToks.length === 0) return makeRunner(() => 1, { kind: 'lock' });
+	const wLit = ((elem.children.weightLiteral as CstNode[]) ?? [])[0];
+	if (!wLit) return makeRunner(() => 1, { kind: 'lock' });
+	const intTok = ((wLit.children.Integer as IToken[]) ?? [])[0];
+	const floatTok = ((wLit.children.Float as IToken[]) ?? [])[0];
+	const value = intTok ? parseInt(intTok.image, 10) : floatTok ? parseFloat(floatTok.image) : 1;
+	return makeRunner(() => value, { kind: 'lock' });
+}
+
+/** True if any sequenceElement in this list carries a `?` weight suffix. */
+function listHasExplicitWeights(seqNode: CstNode): boolean {
+	const elems = (seqNode.children.sequenceElement as CstNode[]) ?? [];
+	for (const el of elems) {
+		if (((el.children.Question as IToken[]) ?? []).length > 0) return true;
+	}
+	return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -1036,7 +1046,7 @@ function compileTransposition(patternNode: CstNode): CompiledTransposition {
 // ---------------------------------------------------------------------------
 
 /** List-level traversal modifier. */
-type TraversalMode = 'seq' | 'shuf' | 'pick' | 'wran';
+type TraversalMode = 'seq' | 'shuf' | 'pick';
 
 type ContentType = 'note' | 'mono' | 'sample' | 'slice' | 'cloud';
 
@@ -1127,7 +1137,12 @@ function compilePattern(
 	let traversal: TraversalMode = 'seq';
 	if (hasModifier(listMods, 'shuf')) traversal = 'shuf';
 	else if (hasModifier(listMods, 'pick')) traversal = 'pick';
-	else if (hasModifier(listMods, 'wran')) traversal = 'wran';
+
+	// Warn when `?` weights are present on a list without 'pick — the weight
+	// is meaningless there and silently ignored. Matches spec truth table 4.
+	if (traversal !== 'pick' && seqNode && listHasExplicitWeights(seqNode)) {
+		console.warn("[flux] `?` weight ignored: weights are only meaningful on lists with 'pick");
+	}
 
 	const compiled: CompiledElement[] = [];
 
@@ -1402,6 +1417,12 @@ function evaluateFxEvent(compiledFx: CompiledFx, cycle: number, atOffset: number
 // Evaluate a compiled loop/line for one cycle
 // ---------------------------------------------------------------------------
 
+/** A slot filled with a rest, returned by 'pick when all weights are zero. */
+const ZERO_WEIGHT_REST: CompiledElement = {
+	kind: 'rest',
+	weight: makeRunner(() => 1, { kind: 'lock' })
+};
+
 /** Apply traversal strategy to an element array, returning the ordered sequence. */
 function orderedSubElements(
 	elements: CompiledElement[],
@@ -1409,19 +1430,13 @@ function orderedSubElements(
 	cycle: number
 ): CompiledElement[] {
 	if (traversal === 'pick') {
-		return elements.map(() => elements[Math.floor(Math.random() * elements.length)]);
-	} else if (traversal === 'shuf') {
-		const arr = [...elements];
-		for (let i = arr.length - 1; i > 0; i--) {
-			const j = Math.floor(Math.random() * (i + 1));
-			[arr[i], arr[j]] = [arr[j], arr[i]];
-		}
-		return arr;
-	} else if (traversal === 'wran') {
+		// Unified weighted selection: unweighted elements default to weight 1,
+		// so a plain [a b c]'pick behaves exactly like uniform random. When all
+		// weights are zero the slot is silent (rest event).
+		const weights = elements.map((el) => sampleRunner(el.weight, cycle));
+		const total = weights.reduce((a, b) => a + b, 0);
+		if (total <= 0) return elements.map(() => ZERO_WEIGHT_REST);
 		return elements.map(() => {
-			const weights = elements.map((el) => Math.max(0, sampleRunner(el.weight, cycle)));
-			const total = weights.reduce((a, b) => a + b, 0);
-			if (total === 0) return elements[0];
 			let r = Math.random() * total;
 			for (let i = 0; i < elements.length; i++) {
 				r -= weights[i];
@@ -1429,6 +1444,13 @@ function orderedSubElements(
 			}
 			return elements[elements.length - 1];
 		});
+	} else if (traversal === 'shuf') {
+		const arr = [...elements];
+		for (let i = arr.length - 1; i > 0; i--) {
+			const j = Math.floor(Math.random() * (i + 1));
+			[arr[i], arr[j]] = [arr[j], arr[i]];
+		}
+		return arr;
 	}
 	return elements; // 'seq
 }

--- a/src/lib/lang/hover.ts
+++ b/src/lib/lang/hover.ts
@@ -211,7 +211,7 @@ const TOKEN_TYPE_DOCS: Record<string, string> = {
 		'',
 		'Attaches a modifier to the immediately preceding token.',
 		'',
-		'Common modifiers: `lock`, `eager(n)`, `stut`, `maybe`, `legato`, `offset`, `at`, `n`, `shuf`, `pick`, `wran`'
+		'Common modifiers: `lock`, `eager(n)`, `stut`, `maybe`, `legato`, `offset`, `at`, `n`, `shuf`, `pick`'
 	].join('\n'),
 
 	At: [
@@ -297,10 +297,10 @@ const TOKEN_TYPE_DOCS: Record<string, string> = {
 		'Yields elements in order, cycling back to the start indefinitely.',
 		'',
 		'```flux',
-		'[1 2 3]         // 1, 2, 3, 1, 2, 3, ...',
-		"[1 2 3]'shuf    // shuffle then traverse",
-		"[1 2 3]'pick    // random element each time",
-		"[1?3 2?1]'wran  // weighted random",
+		'[1 2 3]           // 1, 2, 3, 1, 2, 3, ...',
+		"[1 2 3]'shuf      // shuffle then traverse",
+		"[1 2 3]'pick      // uniform random element each time",
+		"[1 2?2 3]'pick    // weighted random (probs 0.25/0.5/0.25)",
 		'```'
 	].join('\n'),
 
@@ -424,21 +424,12 @@ const MODIFIER_DOCS: Record<string, string> = {
 	pick: [
 		"**`'pick`** — pick a random element each time.",
 		'',
-		'Picks uniformly at random on every poll. Equivalent to Prand.',
+		'Uniform random by default. Optional per-element `?n` weights make selection proportional; unweighted elements default to weight 1. `?0` means the element is never picked. Equivalent to Prand / Pwrand.',
 		'',
 		'```flux',
-		"[1 2 3 4]'pick",
-		'```'
-	].join('\n'),
-
-	wran: [
-		"**`'wran`** — weighted random selection.",
-		'',
-		'Use `?weight` on elements to assign relative weights. Default weight = 1.',
-		'',
-		'```flux',
-		"[1?3 2?1]'wran  // 1 appears 3× as often as 2",
-		"[x?0 y?1]'wran  // zero weight removes entry",
+		"[1 2 3 4]'pick        // uniform",
+		"[1 2?2 3]'pick        // probs 0.25 / 0.5 / 0.25",
+		"[1?0.5 2?1 3?2]'pick  // probs 0.14 / 0.29 / 0.57",
 		'```'
 	].join('\n'),
 

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -384,7 +384,7 @@ describe("modifierSuffix — timing: 'lock and 'eager", () => {
 	});
 });
 
-describe("modifierSuffix — sequence traversal: 'shuf, 'pick, 'wran", () => {
+describe("modifierSuffix — sequence traversal: 'shuf, 'pick", () => {
 	it("parses 'shuf on a list", () => {
 		expect(parse("note lead [0 1 2 3]'shuf").parseErrors).toHaveLength(0);
 	});
@@ -393,12 +393,28 @@ describe("modifierSuffix — sequence traversal: 'shuf, 'pick, 'wran", () => {
 		expect(parse("note lead [0 1 2 3]'pick").parseErrors).toHaveLength(0);
 	});
 
-	it("parses 'wran on a list with weights", () => {
-		expect(parse("note lead [0?2 1?1 2?3]'wran").parseErrors).toHaveLength(0);
+	it("parses 'pick on a list with weights", () => {
+		expect(parse("note lead [0?2 1?1 2?3]'pick").parseErrors).toHaveLength(0);
 	});
 
-	it("parses 'wran on a list without explicit weights", () => {
-		expect(parse("note lead [0 1 2]'wran").parseErrors).toHaveLength(0);
+	it("parses 'pick on a list with a mix of weighted and unweighted elements", () => {
+		expect(parse("note lead [0 1?2 2]'pick").parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'pick with a float weight", () => {
+		expect(parse("note lead [0?0.5 1?1]'pick").parseErrors).toHaveLength(0);
+	});
+
+	it('parses ?0 (zero-weight element)', () => {
+		expect(parse("note lead [0?0 1?1]'pick").parseErrors).toHaveLength(0);
+	});
+
+	it('rejects negative weights: ?-1', () => {
+		expect(parse("note lead [0?-1 1?1]'pick").parseErrors.length).toBeGreaterThan(0);
+	});
+
+	it('rejects generator-expression weights: ?(1rand3)', () => {
+		expect(parse("note lead [0?(1rand3) 1?1]'pick").parseErrors.length).toBeGreaterThan(0);
 	});
 });
 

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -596,23 +596,24 @@ class FluxParser extends CstParser {
 		]);
 		this.OPTION(() => {
 			this.CONSUME(Question);
-			this.OR2([
-				{ ALT: () => this.SUBRULE(this.numericLiteral) },
-				{
-					ALT: () => {
-						this.CONSUME(LParen);
-						// Use SUBRULE2 to distinguish this from the generatorExpr above
-						this.SUBRULE2(this.generatorExpr);
-						this.CONSUME(RParen);
-					}
-				}
-			]);
+			this.SUBRULE(this.weightLiteral);
 		});
 		// `!n` inline repetition: 1!4 expands to four copies of element 1 in the list
 		this.OPTION2(() => {
 			this.CONSUME(Bang);
 			this.CONSUME(Integer);
 		});
+	});
+
+	/**
+	 * Weight literal for `?n` suffixes in `'pick` lists.
+	 *
+	 * Only non-negative numeric literals are valid weights — no leading `-`,
+	 * no parenthesised generator expressions. `?0` is allowed (the element
+	 * has zero probability and is never picked).
+	 */
+	weightLiteral = this.RULE('weightLiteral', () => {
+		this.OR([{ ALT: () => this.CONSUME(Float) }, { ALT: () => this.CONSUME(Integer) }]);
 	});
 
 	/** Returns true if LA(1) is Integer and LA(2) is Sharp or Flat. */


### PR DESCRIPTION
Closes #25

## Summary
- `'wran` is removed. `'pick` now accepts optional per-element `?n` weights; unweighted elements default to weight 1, so `[1 2 3]'pick` stays uniform random.
- `?n` must be a non-negative numeric literal. Negative weights and generator-expression weights (e.g. `?(1rand3)`) are parse errors. Enforced by a new `weightLiteral` parser rule.
- `?0` is allowed: the element is never picked. When every element has weight 0 the slot emits a rest event.
- `?` on a list without `'pick` is ignored and logs a warning. Checked at each list level, so `[[1 2?3]'pick 5]` is fine but `[[1 2?3] 5]'pick` warns.
- `'wran` in user code is silently ignored (existing behaviour for unknown list modifiers) — the list falls back to `seq` traversal.
- Spec and truth table 4 rewritten to describe the unified `'pick`; hover/completion docs updated.

Generated with [Claude Code](https://claude.com/claude-code)