### PR TITLE
feat(docs): clarify [] as the sole non-scalar generator (#39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ E2e tests live in `e2e/` and use Playwright directly (builds the app before runn
 
 ## DSL Documentation
 
-The Flux DSL is documented in `docs/DSL-spec.md` — this is the single source of truth for language design. `docs/DSL-truthtables.md` and `docs/DSL-grammar.ebnf` flesh out the spec into concrete implementation references. Always consult these documents when working on the parser, evaluator, or anything DSL-related. Do not infer DSL behaviour from the codebase; if there is a conflict, the spec rules (ask user if in doubt).
+The Flux DSL is documented in `docs/DSL-spec.md` — this is the single source of truth for language design. `docs/DSL-truthtables.md` fleshes out the spec into a concrete implementation reference. Always consult these documents when working on the parser, evaluator, or anything DSL-related. Do not infer DSL behaviour from the codebase; if there is a conflict, the spec rules (ask user if in doubt).
 
 **Keeping the documents in sync:** any change to the spec that affects observable behaviour must be reflected in the corresponding truth table section, and vice versa. The two files must never contradict each other.
 

--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -23,6 +23,10 @@ Generators are objects that yield a stream of values for use in synth instantiat
 
 Unlike SuperCollider patterns/streams, all generators yield indefinitely. They are never exhausted — it's the caller's responsibility to stop polling when a phrase needs to end.
 
+`[]` is the only non-scalar generator. All other generator forms — numeric literals, `rand`, `gau`, `step`, `mul`, `lin`, `geo`, etc. — are **scalar**: they yield a single value per poll and make no claim about time. `[]` does both: it yields values _and_ assigns each a temporal position within the cycle. This is why nesting `[]` inside `[]` subdivides time (the inner list fills its parent slot with multiple timed events) rather than violating the generator contract — the inner list's temporal extent is simply scaled to fit the outer slot.
+
+This scalar/non-scalar distinction is load-bearing elsewhere in the spec: the right-hand side of transposition and the `'stut` count argument both require a scalar generator and reject `[...]` outright.
+
 ### Whitespace rules
 
 > _See truth tables [12 (Whitespace)](DSL-truthtables.md#12-whitespace-truth-table)._


### PR DESCRIPTION
Closes #39

## Summary
- Add a paragraph to the Generators section of `DSL-spec.md` making the scalar / non-scalar distinction explicit: `[]` is the only generator with temporal extent; all other forms (`rand`, `gau`, `step`, `mul`, `lin`, `geo`, numeric literals) yield one value per poll and make no claim about time.
- Ground the distinction in sections of the spec that already depend on it (the `'stut` count argument and transposition RHS both require scalar generators and reject `[...]`), rather than in a grammar rule — `docs/DSL-grammar.ebnf` doesn't exist.
- Drop the stale `DSL-grammar.ebnf` reference from `CLAUDE.md`.

Generated with [Claude Code](https://claude.com/claude-code)