### PR TITLE
DSL: retire absTimedList — document {} as reserved, add rejection tests

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -27,6 +27,8 @@ Unlike SuperCollider patterns/streams, all generators yield indefinitely. They a
 
 This scalar/non-scalar distinction is load-bearing elsewhere in the spec: the right-hand side of transposition and the `'stut` count argument both require a scalar generator and reject `[...]` outright.
 
+`{}` curly brackets are not assigned to any syntax form and are reserved for future use. Any input containing `{` or `}` is a lex error.
+
 ### Whitespace rules
 
 > _See truth tables [12 (Whitespace)](DSL-truthtables.md#12-whitespace-truth-table)._

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -419,21 +419,24 @@ Direct SynthDef argument access. Valid wherever modifiers are valid.
 
 # 17. **Error Condition Summary**
 
-| Code                  | Failure Type   | Why                                                 |
-| --------------------- | -------------- | --------------------------------------------------- |
-| `[0 1 2`              | Parse error    | Missing `]`.                                        |
-| `note [0] + @root(5)` | Semantic error | Decorator cannot appear as operand.                 |
-| `0rand4rand7`         | Semantic error | Ambiguous construction; parentheses required.       |
-| `note [@root(5) 0]`   | Parse error    | Decorators invalid inside lists.                    |
-| `'stut` alone         | Parse error    | No preceding target.                                |
-| `note` ↵ `  'stut`    | Parse error    | No generator on previous line.                      |
-| `[a?invalid]`         | Parse error    | Weight must be literal or generator.                |
-| `note [0 2] - -4`     | Parse error    | Double-negative transposition; use `+ 4`.           |
-| `note[0]`             | Parse error    | Missing space between content type keyword and `[`. |
-| `0 rand 4`            | Parse error    | Whitespace inside generator expression.             |
-| `[0, 1, 2]`           | Parse error    | Commas not valid as element separators.             |
-| `[x]'eager(0)`        | Semantic error | eager period must be a positive integer ≥ 1.        |
-| `[x]'eager(-1)`       | Semantic error | Negative eager period is not meaningful.            |
-| `note [0]'n(0)`       | Semantic error | Zero repetitions means the pattern never plays.     |
-| `note [0]'n(-1)`      | Semantic error | Negative repetition count is not meaningful.        |
-| `note [0]'n(1.5)`     | Semantic error | Repetition count must be a positive integer.        |
+| Code                  | Failure Type   | Why                                                               |
+| --------------------- | -------------- | ----------------------------------------------------------------- |
+| `[0 1 2`              | Parse error    | Missing `]`.                                                      |
+| `note [0] + @root(5)` | Semantic error | Decorator cannot appear as operand.                               |
+| `0rand4rand7`         | Semantic error | Ambiguous construction; parentheses required.                     |
+| `note [@root(5) 0]`   | Parse error    | Decorators invalid inside lists.                                  |
+| `'stut` alone         | Parse error    | No preceding target.                                              |
+| `note` ↵ `  'stut`    | Parse error    | No generator on previous line.                                    |
+| `[a?invalid]`         | Parse error    | Weight must be literal or generator.                              |
+| `note [0 2] - -4`     | Parse error    | Double-negative transposition; use `+ 4`.                         |
+| `note[0]`             | Parse error    | Missing space between content type keyword and `[`.               |
+| `0 rand 4`            | Parse error    | Whitespace inside generator expression.                           |
+| `[0, 1, 2]`           | Parse error    | Commas not valid as element separators.                           |
+| `[x]'eager(0)`        | Semantic error | eager period must be a positive integer ≥ 1.                      |
+| `[x]'eager(-1)`       | Semantic error | Negative eager period is not meaningful.                          |
+| `note [0]'n(0)`       | Semantic error | Zero repetitions means the pattern never plays.                   |
+| `note [0]'n(-1)`      | Semantic error | Negative repetition count is not meaningful.                      |
+| `{4:1/2 7:3/2}`       | Lex error      | `{}` curly brackets are reserved; no token exists for `{` or `}`. |
+| `{`                   | Lex error      | Lone `{` is unrecognised by the lexer.                            |
+| `}`                   | Lex error      | Lone `}` is unrecognised by the lexer.                            |
+| `note [0]'n(1.5)`     | Semantic error | Repetition count must be a positive integer.                      |

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -687,6 +687,37 @@ describe('"param — direct SynthDef argument access', () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// absTimedList — retired syntax: {} brackets must NOT parse
+//
+// The {time:degree} absolute-timed list syntax was never implemented and has
+// been officially retired (issue #36). {} brackets are free for future use.
+// Verify that any input containing '{' produces lex errors — the lexer has
+// no token for curly braces, so they are always illegal.
+// ---------------------------------------------------------------------------
+
+describe('absTimedList — retired {} syntax is rejected', () => {
+	it('rejects bare curly-brace timed list: {4:1/2 7:3/2}', () => {
+		const { lexErrors } = parse('{4:1/2 7:3/2}');
+		expect(lexErrors.length).toBeGreaterThan(0);
+	});
+
+	it('rejects curly-brace timed list as pattern body: note lead {4:1/2 7:3/2}', () => {
+		const { lexErrors } = parse('note lead {4:1/2 7:3/2}');
+		expect(lexErrors.length).toBeGreaterThan(0);
+	});
+
+	it('rejects a lone opening curly brace', () => {
+		const { lexErrors } = parse('{');
+		expect(lexErrors.length).toBeGreaterThan(0);
+	});
+
+	it('rejects a lone closing curly brace', () => {
+		const { lexErrors } = parse('}');
+		expect(lexErrors.length).toBeGreaterThan(0);
+	});
+});
+
 describe('derived generators — child:parent syntax', () => {
 	it("parses derived generator: sample perc:drums 'at(1/8)", () => {
 		expect(parse("sample perc:drums 'at(1/8)").parseErrors).toHaveLength(0);


### PR DESCRIPTION
## Summary

- Formally retires the `absTimedList` (`{time:degree}`) syntax which was specified but never implemented
- Adds a spec note to `docs/DSL-spec.md` that `{}` curly brackets are not assigned to any syntax form and are reserved for future use
- Adds four parser tests that explicitly verify `{4:1/2 7:3/2}` and related `{}` forms produce lex errors

## What changed

**`docs/DSL-spec.md`** — one sentence added to the Generators section:

> `{}` curly brackets are not assigned to any syntax form and are reserved for future use. Any input containing `{` or `}` is a lex error.

**`src/lib/lang/parser.test.ts`** — new `describe` block with 4 tests:
- `{4:1/2 7:3/2}` → lex error
- `note lead {4:1/2 7:3/2}` → lex error
- `{` alone → lex error
- `}` alone → lex error

## Design notes

No changes to `parser.ts` or `lexer.ts` were required — the lexer never had a `{` or `}` token, so the syntax was already rejected. The tests make this invariant explicit and prevent accidental future introduction.

`docs/DSL-grammar.ebnf` referenced in the issue does not exist as a separate file — the grammar is embedded in `docs/DSL-spec.md`. No grammar EBNF file needed updating.

Closes #36