### PR TITLE
feat(DSL): Array range notation [start..end] and [start, step..end]

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -35,7 +35,7 @@ This scalar/non-scalar distinction is load-bearing elsewhere in the spec: the ri
 
 Whitespace (spaces or newlines) is required between distinct top-level tokens — for example, between `note` and `[`. Inside generator expressions, however, tokens are written **adjacently with no whitespace**: `0rand4`, not `0 rand 4`. The same applies to all generator keywords (`gau`, `exp`, `bro`, `step`, `mul`, `lin`, `geo`) and their separators (`m`, `x`). Whitespace inside a generator expression is a syntax error.
 
-Inside `[...]` sequence generators, elements are separated by spaces. Commas are not valid separators.
+Inside `[...]` sequence generators, elements are separated by spaces. Commas are not valid separators — except inside a range expression (see below).
 
 ### Sequence generators
 
@@ -57,6 +57,34 @@ Inside `[...]` sequence generators, elements are separated by spaces. Commas are
 - Negative weights (e.g. `?-1`) are a parse error.
 - Generator expressions are not valid as weights — `?` must be followed by a numeric literal.
 - The `?` weight syntax is only meaningful on a list whose own modifiers include `'pick`. Using `?` on a list without `'pick` is not an error, but the weight is ignored and a warning is logged. This rule applies per list level: `[[1 2?3]'pick 5]` is fine, but `[[1 2?3] 5]'pick` ignores the inner `?3` because the inner list has no `'pick`.
+
+### Range notation
+
+> _See truth table [22 (Range notation)](DSL-truthtables.md#22-range-notation-truth-table)._
+
+A compact SC-inspired syntax for generating integer or float sequences inside `[...]`. All bounds are inclusive.
+
+```flux
+[0..7]            // [0 1 2 3 4 5 6 7]
+[0, 2..10]        // [0 2 4 6 8 10]
+[0.0, 0.25..1.0]  // [0.0 0.25 0.5 0.75 1.0]
+[10, 8..0]        // [10 8 6 4 2 0]  (descending)
+```
+
+**Forms:**
+
+- `[start..end]` — integer range; step defaults to `1` if `end >= start`, `-1` if `end < start`.
+- `[start, step..end]` — explicit step; the step value equals `second − first`.
+
+**Rules:**
+
+- Both bounds are inclusive.
+- Float ranges require an explicit step — `[0.0..1.0]` is a parse error (the parser rejects a float before `..` with no preceding comma).
+- Descending ranges are valid when `end < start` (default step `-1`) or when the explicit step would count down toward `end`.
+- A range that produces zero elements is a semantic error (e.g. `[0, 0..5]` — step of 0; or `[5..0]` with positive step 1 would produce 0 elements if start > end but is handled by auto-negating the step).
+- Ranges are eagerly expanded to a flat value array at parse/compile time — they behave identically to an explicit list `[v1 v2 ... vN]`.
+- A range list may carry the usual list modifiers (`'shuf`, `'pick`, `'lock`, etc.) after the `]`.
+- Slice selection: `[0..15]` is the natural way to express a pool of 16 slices (e.g. `slice drums [0..15]'pick`).
 
 ### Rests
 

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -481,3 +481,29 @@ Converts a bare identifier to its UTF-8 byte sequence and yields the bytes cycli
 | `utf8{}`           | Parse error  | Empty braces — identifier is required inside `{}`.                                                             |
 | `utf8{1coffee}`    | Parse error  | Content must be a valid identifier (cannot start with a digit).                                                |
 | `utf8{coffee bar}` | Parse error  | Only a single bare identifier is allowed; spaces are not permitted.                                            |
+
+---
+
+# 22. **Range Notation Truth Table**
+
+Compact `[start..end]` / `[start, step..end]` syntax. All bounds inclusive. Eagerly expanded to a flat value array at compile time.
+
+| Code Snippet          | Interpretation                                 | Evaluation                                      | Result                   |
+| --------------------- | ---------------------------------------------- | ----------------------------------------------- | ------------------------ |
+| `[0..7]`              | Integer range, default step 1.                 | Expand to `[0 1 2 3 4 5 6 7]`.                  | 8 elements: 0–7.         |
+| `[0, 2..10]`          | Integer range, explicit step 2 (second−first). | Expand to `[0 2 4 6 8 10]`.                     | 6 elements.              |
+| `[0.0, 0.25..1.0]`    | Float range, explicit step 0.25.               | Expand to `[0.0 0.25 0.5 0.75 1.0]`.            | 5 float elements.        |
+| `[10, 8..0]`          | Descending, explicit step −2.                  | Expand to `[10 8 6 4 2 0]`.                     | 6 elements, descending.  |
+| `[5..0]`              | Descending, default step −1.                   | Expand to `[5 4 3 2 1 0]`.                      | 6 elements.              |
+| `[0..0]`              | Single-element range.                          | Expand to `[0]`.                                | 1 element.               |
+| `[0..3]'shuf`         | Range with modifier.                           | Expand then apply `'shuf`.                      | `[0 1 2 3]` shuffled.    |
+| `[0..3]'pick`         | Range with `'pick`.                            | Expand then pick randomly each slot.            | Uniform random from 0–3. |
+| `slice drums [0..15]` | Range as slice pool.                           | Expand to 16 elements; slice index cycles 0→15. | All 16 slices in order.  |
+
+**Error cases**
+
+| Code         | Failure Type   | Why                                                                                                 |
+| ------------ | -------------- | --------------------------------------------------------------------------------------------------- |
+| `[0.0..1.0]` | Parse error    | Float before `..` with no preceding comma (no explicit step); step would be fractional and unknown. |
+| `[0, 0..5]`  | Semantic error | Step of zero produces an infinite loop; rejected at compile time.                                   |
+| `[0, 2..1]`  | Semantic error | Step (2) goes the wrong direction relative to end (1), so no elements would be produced.            |

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -2773,3 +2773,14 @@ describe('range notation — error cases', () => {
 		expect(i.ok).toBe(false);
 	});
 });
+
+describe('range notation — nested inside outer list', () => {
+	it('[[0..3] 4] — nested range subdivides parent slot', () => {
+		// The spec says ranges behave identically to explicit lists.
+		// [[0..3] 4] should behave like [[0 1 2 3] 4]: 2 top-level slots,
+		// first slot subdivided into 4 sub-events.
+		const evs = eval0('note x [[0..3] 4]');
+		// 2 top-level slots → 1 with 4 sub-events + 1 scalar = 5 total events
+		expect(evs).toHaveLength(5);
+	});
+});

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -2618,3 +2618,158 @@ describe('utf8{word} generator', () => {
 		expect(i.ok).toBe(true);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 22. Range notation — [start..end] and [start, step..end]
+// (truth table 22)
+// C major degree → MIDI: 0→60, 1→62, 2→64, 3→65, 4→67, 5→69, 6→71, 7→72
+// ---------------------------------------------------------------------------
+
+describe('range notation — [start..end]', () => {
+	it('[0..7] expands to 8 events, degrees 0–7', () => {
+		const ns = notes('note x [0..7]');
+		expect(ns).toHaveLength(8);
+		// degrees 0..7 in C major: C5=60, D5=62, E5=64, F5=65, G5=67, A5=69, B5=71, C6=72
+		expect(ns).toEqual([60, 62, 64, 65, 67, 69, 71, 72]);
+	});
+
+	it('[5..0] descending default step produces degrees 5,4,3,2,1,0', () => {
+		const ns = notes('note x [5..0]');
+		expect(ns).toHaveLength(6);
+		expect(ns).toEqual([69, 67, 65, 64, 62, 60]); // degrees 5,4,3,2,1,0
+	});
+
+	it('[0..0] single-element range produces 1 event', () => {
+		const ns = notes('note x [0..0]');
+		expect(ns).toHaveLength(1);
+		expect(ns[0]).toBe(60); // degree 0 = C5
+	});
+
+	it('[3..3] single-element range at degree 3', () => {
+		const ns = notes('note x [3..3]');
+		expect(ns).toHaveLength(1);
+		expect(ns[0]).toBe(65); // degree 3 = F5
+	});
+
+	it('[0..3] produces 4 events — degrees 0,1,2,3', () => {
+		const ns = notes('note x [0..3]');
+		expect(ns).toHaveLength(4);
+		expect(ns).toEqual([60, 62, 64, 65]);
+	});
+
+	it('range events have evenly-spaced beat offsets', () => {
+		const evs = eval0('note x [0..3]');
+		expect(evs).toHaveLength(4);
+		expect(evs[0].beatOffset).toBeCloseTo(0);
+		expect(evs[1].beatOffset).toBeCloseTo(0.25);
+		expect(evs[2].beatOffset).toBeCloseTo(0.5);
+		expect(evs[3].beatOffset).toBeCloseTo(0.75);
+	});
+
+	it('[0..3] produces correct slot durations', () => {
+		const ds = durations('note x [0..3]');
+		// 4 events, slot = 1/4, default legato 0.8
+		for (const d of ds) expect(d).toBeCloseTo(0.25 * 0.8);
+	});
+
+	it('range is eagerly expanded — same result every cycle', () => {
+		const i = inst('note x [0..3]');
+		const r0 = i.evaluate({ cycleNumber: 0 });
+		const r1 = i.evaluate({ cycleNumber: 1 });
+		if (!r0.ok || !r1.ok) throw new Error('eval failed');
+		expect(r0.events.map((e) => pitched(e).note)).toEqual(r1.events.map((e) => pitched(e).note));
+	});
+
+	it('negative start: [-3..0] produces degrees -3,-2,-1,0', () => {
+		const ns = notes('note x [-3..0]');
+		expect(ns).toHaveLength(4);
+		// degree -3: below C5 by 3 diatonic steps in C major (going down)
+		// degree 0 = C5 = 60; verify count and last element
+		expect(ns[ns.length - 1]).toBe(60); // degree 0 = C5
+	});
+});
+
+describe('range notation — [start, step..end]', () => {
+	it('[0, 2..10] — every-other step, produces degrees 0,2,4,6,8,10', () => {
+		const ns = notes('note x [0, 2..10]');
+		expect(ns).toHaveLength(6);
+		// degrees 0,2,4,6,8,10 in C major
+		expect(ns[0]).toBe(60); // degree 0 = C5
+		expect(ns[1]).toBe(64); // degree 2 = E5
+		expect(ns[2]).toBe(67); // degree 4 = G5
+	});
+
+	it('[10, 8..0] — descending step -2, produces 10,8,6,4,2,0', () => {
+		// degrees 10,8,6,4,2,0 → last is degree 0 = C5 = 60
+		const ns = notes('note x [10, 8..0]');
+		expect(ns).toHaveLength(6);
+		expect(ns[ns.length - 1]).toBe(60); // degree 0 = C5
+	});
+
+	it('[0, 3..9] — step 3, produces degrees 0,3,6,9', () => {
+		const ns = notes('note x [0, 3..9]');
+		expect(ns).toHaveLength(4);
+		expect(ns[0]).toBe(60); // degree 0 = C5
+		expect(ns[1]).toBe(65); // degree 3 = F5
+	});
+
+	it('[0.0, 0.25..1.0] — float range with step 0.25 produces 5 events', () => {
+		// Float ranges go through the pitch chain (float degrees are rounded for MIDI)
+		// This tests that the evaluator produces 5 events: 0.0, 0.25, 0.5, 0.75, 1.0
+		const evs = eval0('note x [0.0, 0.25..1.0]');
+		expect(evs).toHaveLength(5);
+	});
+});
+
+describe('range notation — with modifiers', () => {
+	it("[0..3]'shuf — same 4 elements shuffled each cycle", () => {
+		const i = inst("note x [0..3]'shuf");
+		// Collect notes over several cycles — should always be exactly {60,62,64,65}
+		const allNotes: Set<number> = new Set();
+		for (let c = 0; c < 10; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			for (const e of r.events) allNotes.add(pitched(e).note);
+		}
+		expect(allNotes).toEqual(new Set([60, 62, 64, 65]));
+	});
+
+	it("[0..3]'pick — all notes in {60,62,64,65} across many cycles", () => {
+		const i = inst("note x [0..3]'pick");
+		const allNotes: Set<number> = new Set();
+		for (let c = 0; c < 50; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			for (const e of r.events) allNotes.add(pitched(e).note);
+		}
+		// All notes should be within the expanded range
+		for (const n of allNotes) {
+			expect([60, 62, 64, 65]).toContain(n);
+		}
+	});
+
+	it('slice drums [0..15] — range as slice pool produces 16 events', () => {
+		const evs = eval0('slice drums [0..15]');
+		expect(evs).toHaveLength(16);
+		const sliceEvs = evs as SliceEvent[];
+		expect(sliceEvs[0].sliceIndex).toBe(0);
+		expect(sliceEvs[15].sliceIndex).toBe(15);
+	});
+});
+
+describe('range notation — error cases', () => {
+	it('[0.0..1.0] without explicit step is a parse/lex error', () => {
+		const i = createInstance('note x [0.0..1.0]');
+		expect(i.ok).toBe(false);
+	});
+
+	it('[0, 0..5] — zero step is a semantic error', () => {
+		const i = createInstance('note x [0, 0..5]');
+		expect(i.ok).toBe(false);
+	});
+
+	it('[0, 2..1] — step goes wrong direction is a semantic error', () => {
+		const i = createInstance('note x [0, 2..1]');
+		expect(i.ok).toBe(false);
+	});
+});

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -387,6 +387,121 @@ function utf8GenToPollFn(utf8Node: CstNode): PollFn | null {
 }
 
 // ---------------------------------------------------------------------------
+// rangeExpr — eager expansion helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the numeric value from a rangeBound or intBound CST node.
+ * Returns the number (signed if Minus is present), or null on error.
+ */
+function rangeBoundToNumber(bound: CstNode): number | null {
+	const negative = ((bound.children.Minus as IToken[]) ?? []).length > 0;
+	const intTok = ((bound.children.Integer as IToken[]) ?? [])[0];
+	const floatTok = ((bound.children.Float as IToken[]) ?? [])[0];
+	let value: number | null = null;
+	if (intTok) value = parseInt(intTok.image, 10);
+	else if (floatTok) value = parseFloat(floatTok.image);
+	if (value === null) return null;
+	return negative ? -value : value;
+}
+
+/**
+ * Expand a rangeExpr CST node to a flat array of numeric values.
+ *
+ * Returns an error string if the range is semantically invalid:
+ *   - Zero step → error
+ *   - Step going wrong direction (no elements would be produced) → error
+ *
+ * Both inclusive bounds.
+ */
+function expandRangeExpr(rangeNode: CstNode): number[] | string {
+	const bounds = (rangeNode.children.rangeBound as CstNode[]) ?? [];
+	const intBounds = (rangeNode.children.intBound as CstNode[]) ?? [];
+	const hasComma = ((rangeNode.children.Comma as IToken[]) ?? []).length > 0;
+
+	let start: number;
+	let stepOrSecond: number | null = null;
+	let end: number;
+
+	if (hasComma) {
+		// Stepped form: rangeBound[0]=start, rangeBound[1]=step, rangeBound[2]=end
+		if (bounds.length < 3) return 'range: malformed stepped range (need start, step, end)';
+		const s = rangeBoundToNumber(bounds[0]);
+		const t = rangeBoundToNumber(bounds[1]);
+		const e = rangeBoundToNumber(bounds[2]);
+		if (s === null || t === null || e === null) return 'range: could not parse bounds';
+		start = s;
+		stepOrSecond = t;
+		end = e;
+	} else {
+		// No-step form: intBound[0]=start, rangeBound[0]=end (integer only)
+		if (intBounds.length < 1 || bounds.length < 1)
+			return 'range: malformed no-step range (need start, end)';
+		const s = rangeBoundToNumber(intBounds[0]);
+		const e = rangeBoundToNumber(bounds[0]);
+		if (s === null || e === null) return 'range: could not parse bounds';
+		start = s;
+		end = e;
+	}
+
+	// Compute step
+	let step: number;
+	if (hasComma && stepOrSecond !== null) {
+		// Explicit step: step = second_value - start
+		step = stepOrSecond - start;
+	} else {
+		// Default step: 1 if ascending, -1 if descending
+		step = end >= start ? 1 : -1;
+	}
+
+	// Validate step
+	if (step === 0) {
+		return `range: step of zero would produce an infinite sequence — use a non-zero step`;
+	}
+
+	// Validate direction: step must point from start toward end.
+	// For the stepped form [start, second..end], 'second' is the first step value.
+	// If second already overshoots end (e.g. [0, 2..1] → second=2 > end=1 with step>0),
+	// the range is semantically invalid.
+	if (step > 0) {
+		if (start > end) {
+			return `range: positive step (${step}) cannot reach end (${end}) from start (${start})`;
+		}
+		if (hasComma && stepOrSecond !== null && stepOrSecond > end + Number.EPSILON) {
+			return `range: step value (${stepOrSecond}) overshoots end (${end}) from start (${start})`;
+		}
+	}
+	if (step < 0) {
+		if (start < end) {
+			return `range: negative step (${step}) cannot reach end (${end}) from start (${start})`;
+		}
+		if (hasComma && stepOrSecond !== null && stepOrSecond < end - Number.EPSILON) {
+			return `range: step value (${stepOrSecond}) overshoots end (${end}) from start (${start})`;
+		}
+	}
+
+	// Expand: include both bounds
+	const values: number[] = [];
+	const isFloat = !Number.isInteger(start) || !Number.isInteger(step) || !Number.isInteger(end);
+
+	if (step > 0) {
+		for (let v = start; v <= end + Number.EPSILON; v += step) {
+			values.push(isFloat ? v : Math.round(v));
+		}
+	} else {
+		for (let v = start; v >= end - Number.EPSILON; v += step) {
+			values.push(isFloat ? v : Math.round(v));
+		}
+	}
+
+	if (values.length === 0) {
+		return `range: produces zero elements (start=${start}, step=${step}, end=${end})`;
+	}
+
+	return values;
+}
+
+// ---------------------------------------------------------------------------
 // CST compilation: numericGenerator → PollFn
 // ---------------------------------------------------------------------------
 
@@ -1232,6 +1347,7 @@ type CompiledPattern = {
  * Parser structure: modifiers written after [...] are consumed by sequenceExpr's
  * MANY2, not by patternStatement's MANY. So we must look in sequenceExpr or
  * relTimedList as well as on the pattern node itself.
+ * For range expressions, the modifiers live on the rangeExpr child node.
  * Continuation modifiers are found as continuationModifier children on the pattern node.
  */
 function collectPatternModifiers(patternNode: CstNode): CstNode[] {
@@ -1239,7 +1355,17 @@ function collectPatternModifiers(patternNode: CstNode): CstNode[] {
 	const seqNode =
 		((patternNode.children.sequenceExpr as CstNode[]) ?? [])[0] ??
 		((patternNode.children.relTimedList as CstNode[]) ?? [])[0];
-	const seqMods = seqNode ? ((seqNode.children.modifierSuffix as CstNode[]) ?? []) : [];
+
+	let seqMods: CstNode[] = [];
+	if (seqNode) {
+		// For range expressions, modifiers are on the rangeExpr child
+		const rangeNode = ((seqNode.children.rangeExpr as CstNode[]) ?? [])[0];
+		if (rangeNode) {
+			seqMods = (rangeNode.children.modifierSuffix as CstNode[]) ?? [];
+		} else {
+			seqMods = (seqNode.children.modifierSuffix as CstNode[]) ?? [];
+		}
+	}
 
 	// Any modifier suffixes directly on the pattern statement (rare — after transposition etc.)
 	const directMods = (patternNode.children.modifierSuffix as CstNode[]) ?? [];
@@ -1283,11 +1409,20 @@ function compilePattern(
 	const relNode = ((patternNode.children.relTimedList as CstNode[]) ?? [])[0];
 	const utf8Node = ((patternNode.children.utf8Generator as CstNode[]) ?? [])[0];
 
+	// Check if seqNode contains a rangeExpr child — if so, use range path
+	const rangeNode = seqNode ? (((seqNode.children.rangeExpr as CstNode[]) ?? [])[0] ?? null) : null;
+
 	const bodyNode = seqNode ?? relNode ?? utf8Node ?? null;
 	if (!bodyNode && !parentPattern) return 'pattern has no sequence body';
 
-	// List-level modifiers (on the [...] itself)
-	const listMods = bodyNode ? ((bodyNode.children.modifierSuffix as CstNode[]) ?? []) : [];
+	// List-level modifiers:
+	// - For range expressions: modifiers live on the rangeExpr node
+	// - For regular sequences: modifiers live on the sequenceExpr node directly
+	const listMods = rangeNode
+		? ((rangeNode.children.modifierSuffix as CstNode[]) ?? [])
+		: bodyNode
+			? ((bodyNode.children.modifierSuffix as CstNode[]) ?? [])
+			: [];
 	const listMode = extractEagerMode(listMods) ?? DEFAULT_MODE;
 
 	// Traversal mode
@@ -1297,13 +1432,26 @@ function compilePattern(
 
 	// Warn when `?` weights are present on a list without 'pick — the weight
 	// is meaningless there and silently ignored. Matches spec truth table 4.
-	if (traversal !== 'pick' && seqNode && listHasExplicitWeights(seqNode)) {
+	if (traversal !== 'pick' && seqNode && !rangeNode && listHasExplicitWeights(seqNode)) {
 		console.warn("[flux] `?` weight ignored: weights are only meaningful on lists with 'pick");
 	}
 
 	const compiled: CompiledElement[] = [];
 
-	if (seqNode) {
+	if (rangeNode) {
+		// Range expression: eagerly expand to a flat value array
+		const values = expandRangeExpr(rangeNode);
+		if (typeof values === 'string') return `Semantic error: ${values}`;
+		for (const v of values) {
+			const val = v;
+			compiled.push({
+				kind: 'scalar',
+				runner: makeRunner(() => val, listMode),
+				accidentalOffset: 0,
+				weight: makeRunner(() => 1, { kind: 'lock' })
+			});
+		}
+	} else if (seqNode) {
 		const elements = (seqNode.children.sequenceElement as CstNode[]) ?? [];
 		for (const elem of elements) {
 			const ce = compileElement(elem, listMode);

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -424,7 +424,7 @@ function expandRangeExpr(rangeNode: CstNode): number[] | string {
 	let end: number;
 
 	if (hasComma) {
-		// Stepped form: rangeBound[0]=start, rangeBound[1]=step, rangeBound[2]=end
+		// Stepped form: rangeBound[0]=start, rangeBound[1]=second (step = second−start), rangeBound[2]=end
 		if (bounds.length < 3) return 'range: malformed stepped range (need start, step, end)';
 		const s = rangeBoundToNumber(bounds[0]);
 		const t = rangeBoundToNumber(bounds[1]);

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -764,8 +764,35 @@ function compileElement(elem: CstNode, inherited: EagerMode): CompiledElement | 
 
 	// Handle nested sequence generator: [1 2] inside [0 4 [1 2]]
 	// The sub-list subdivides the parent slot — each sub-element gets slot/n time.
+	// Also handles nested range expressions: [[0..3] 4] behaves like [[0 1 2 3] 4].
 	const seqGen = ((atomic.children.sequenceGenerator as CstNode[]) ?? [])[0];
 	if (seqGen) {
+		// Check if this is a range expression inside the sequence generator
+		const subRangeNode = ((seqGen.children.rangeExpr as CstNode[]) ?? [])[0];
+		if (subRangeNode) {
+			// Nested range: expand to flat values and build a sub-sequence.
+			// Modifiers live on the rangeExpr node, not directly on seqGen.
+			const subListMods = (subRangeNode.children.modifierSuffix as CstNode[]) ?? [];
+			const subListMode = extractEagerMode(subListMods) ?? inherited;
+			let subTraversal: TraversalMode = 'seq';
+			if (hasModifier(subListMods, 'shuf')) subTraversal = 'shuf';
+			else if (hasModifier(subListMods, 'pick')) subTraversal = 'pick';
+			const expandedValues = expandRangeExpr(subRangeNode);
+			if (typeof expandedValues === 'string') return null; // semantic error in nested range
+			const subElements: CompiledElement[] = expandedValues.map((v) => ({
+				kind: 'scalar' as const,
+				runner: makeRunner(() => v, subListMode),
+				accidentalOffset: 0,
+				weight: makeRunner(() => 1, { kind: 'lock' })
+			}));
+			return {
+				kind: 'sequence',
+				elements: subElements,
+				traversal: subTraversal,
+				weight: makeRunner(() => 1, { kind: 'lock' })
+			};
+		}
+
 		const subListMods = (seqGen.children.modifierSuffix as CstNode[]) ?? [];
 		const subListMode = extractEagerMode(subListMods) ?? inherited;
 		let subTraversal: TraversalMode = 'seq';

--- a/src/lib/lang/lexer.test.ts
+++ b/src/lib/lang/lexer.test.ts
@@ -39,7 +39,9 @@ import {
 	ParamSigil,
 	Utf8Kw,
 	LCurly,
-	RCurly
+	RCurly,
+	DotDot,
+	Comma
 } from './lexer.js';
 
 describe('FluxLexer', () => {
@@ -722,5 +724,64 @@ describe('utf8 generator tokens', () => {
 	it('bare "}" without utf8 context is a lex error', () => {
 		const { errors } = FluxLexer.tokenize('}');
 		expect(errors.length).toBeGreaterThan(0);
+	});
+});
+
+describe('DotDot — range separator token', () => {
+	it('tokenizes ".." as a single DotDot token', () => {
+		const { tokens, errors } = FluxLexer.tokenize('..');
+		expect(errors).toHaveLength(0);
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].tokenType).toBe(DotDot);
+		expect(tokens[0].image).toBe('..');
+	});
+
+	it('tokenizes "[0..7]" correctly as LBracket Integer DotDot Integer RBracket', () => {
+		const { tokens, errors } = FluxLexer.tokenize('[0..7]');
+		expect(errors).toHaveLength(0);
+		expect(tokens[0].tokenType).toBe(LBracket);
+		expect(tokens[1].tokenType).toBe(Integer);
+		expect(tokens[1].image).toBe('0');
+		expect(tokens[2].tokenType).toBe(DotDot);
+		expect(tokens[3].tokenType).toBe(Integer);
+		expect(tokens[3].image).toBe('7');
+		expect(tokens[4].tokenType).toBe(RBracket);
+	});
+
+	it('tokenizes "[0.0, 0.25..1.0]" — Float Comma Float DotDot Float', () => {
+		const { tokens, errors } = FluxLexer.tokenize('[0.0, 0.25..1.0]');
+		expect(errors).toHaveLength(0);
+		// LBracket Float Comma Float DotDot Float RBracket
+		expect(tokens[1].tokenType).toBe(Float);
+		expect(tokens[2].tokenType).toBe(Comma);
+		expect(tokens[3].tokenType).toBe(Float);
+		expect(tokens[4].tokenType).toBe(DotDot);
+		expect(tokens[5].tokenType).toBe(Float);
+	});
+
+	it('".." does not match inside a regular Float like "0.5"', () => {
+		// 0.5 should lex as Float, not Integer + DotDot + something
+		const { tokens, errors } = FluxLexer.tokenize('0.5');
+		expect(errors).toHaveLength(0);
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].tokenType).toBe(Float);
+	});
+});
+
+describe('Comma — range-specific separator token', () => {
+	it('tokenizes "," as a single Comma token', () => {
+		const { tokens, errors } = FluxLexer.tokenize(',');
+		expect(errors).toHaveLength(0);
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].tokenType).toBe(Comma);
+	});
+
+	it('tokenizes "[0, 2..10]" with Comma between start and step', () => {
+		const { tokens, errors } = FluxLexer.tokenize('[0, 2..10]');
+		expect(errors).toHaveLength(0);
+		const commaIdx = tokens.findIndex((t) => t.tokenType === Comma);
+		expect(commaIdx).toBeGreaterThan(0);
+		expect(tokens[commaIdx - 1].tokenType).toBe(Integer);
+		expect(tokens[commaIdx + 1].tokenType).toBe(Integer);
 	});
 });

--- a/src/lib/lang/lexer.ts
+++ b/src/lib/lang/lexer.ts
@@ -582,6 +582,30 @@ export const Percent = createToken({
 });
 
 /**
+ * `..` — range separator in sequence generators: `[0..7]`, `[0, 2..10]`.
+ * Must appear BEFORE Float in allTokens so that `0..7` does not lex as
+ * Float(`0.`) + something. The pattern `/\.\./` is two literal dots —
+ * unambiguous since `.` alone never appears as a token.
+ */
+export const DotDot = createToken({
+	name: 'DotDot',
+	pattern: /\.\./
+	// Monaco scope: 'operator'
+});
+
+/**
+ * `,` — range-step separator: `[0, 2..10]`.
+ * Only meaningful inside a range expression; the parser treats a bare `,`
+ * outside of a range as a parse error (commas are not general element
+ * separators).
+ */
+export const Comma = createToken({
+	name: 'Comma',
+	pattern: /,/
+	// Monaco scope: 'delimiter'
+});
+
+/**
  * `_` — rest: a silent slot in a sequence. No synth is spawned; the slot occupies time.
  * Uses a custom pattern that matches a standalone `_` — not followed by alphanumeric or
  * additional underscore characters — so that identifiers like `_foo` or `__bar` still
@@ -609,16 +633,22 @@ export const Rest = createToken({
 // ---------------------------------------------------------------------------
 
 /**
- * Float literal, e.g. `0.5`, `1.2`.
+ * Float literal, e.g. `0.5`, `1.2`, `0.` (used in `0.rand4`).
  * Must appear BEFORE Integer in allTokens — `0.5` would otherwise lex as
  * Integer(`0`) then an error on `.5`.
  *
- * The pattern requires digits on both sides of the dot.
+ * The pattern requires at least one digit before the dot, then an optional
+ * sequence of digits after it. The negative lookahead `(?!\.)` prevents
+ * consuming the first dot of a `..` range separator — e.g. in `0..7` the
+ * Float pattern does NOT match `0.` because the dot is immediately followed
+ * by another dot; Integer(`0`) + DotDot(`..`) + Integer(`7`) is produced
+ * instead.
+ *
  * `0.rand4` (float-rand form) is handled by Float + Rand + Integer.
  */
 export const Float = createToken({
 	name: 'Float',
-	pattern: /\d+\.\d*/
+	pattern: /\d+\.(?!\.)\d*/
 	// Monaco scope: 'number'
 });
 
@@ -749,6 +779,9 @@ export const allTokens = [
 	Colon,
 	Bang,
 	Percent,
+	// Range operators — DotDot before Float so '..' is not eaten by the Float pattern
+	DotDot, // '..' — range separator
+	Comma, // ',' — range step separator
 	// Literals — Float before Integer
 	Float,
 	Integer,

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -834,3 +834,74 @@ describe('utf8Generator — parser', () => {
 		expect(lexErrors.length + parseErrors.length).toBeGreaterThan(0);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Range notation — [start..end] and [start, step..end]
+// ---------------------------------------------------------------------------
+
+describe('range notation — parser', () => {
+	it('parses [0..7] — integer range with default step', () => {
+		const { parseErrors, lexErrors } = parse('note lead [0..7]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses [0, 2..10] — integer range with explicit step', () => {
+		const { parseErrors, lexErrors } = parse('note lead [0, 2..10]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses [0.0, 0.25..1.0] — float range with explicit step', () => {
+		const { parseErrors, lexErrors } = parse('note lead [0.0, 0.25..1.0]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses [10, 8..0] — descending range with explicit step', () => {
+		const { parseErrors, lexErrors } = parse('note lead [10, 8..0]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses [5..0] — descending range with default step', () => {
+		const { parseErrors, lexErrors } = parse('note lead [5..0]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses [0..3]'shuf — range with modifier", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..3]'shuf");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses [0..3]'pick — range with pick", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..3]'pick");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses slice drums [0..15] — range as slice pool', () => {
+		const { parseErrors, lexErrors } = parse('slice drums [0..15]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses [0..0] — single-element range', () => {
+		const { parseErrors, lexErrors } = parse('note lead [0..0]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses negative start: [-3..3]', () => {
+		const { parseErrors, lexErrors } = parse('note lead [-3..3]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('rejects float before ".." with no comma — [0.0..1.0] is a parse error', () => {
+		const { parseErrors, lexErrors } = parse('note lead [0.0..1.0]');
+		expect(parseErrors.length + lexErrors.length).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -683,7 +683,7 @@ class FluxParser extends CstParser {
 	 * CST children (both forms share the same rangeExpr node):
 	 *   rangeBound[0]  — start bound
 	 *   Comma[0]       — present only in the stepped form
-	 *   rangeBound[1]  — step value (only when Comma is present)
+	 *   rangeBound[1]  — second value (the explicit step value; actual step = second − start)
 	 *   DotDot[0]      — the ".." separator
 	 *   rangeBound[N]  — end bound (index 1 in no-step form, 2 in stepped form)
 	 *
@@ -722,12 +722,12 @@ class FluxParser extends CstParser {
 
 	/**
 	 * Lookahead: returns true if inside a range bracket we see start, comma before DotDot.
-	 * i.e. the token stream after `[` looks like: `bound , bound ..`
-	 * We are already past LA(1)=`[`, so scan from LA(2).
+	 * i.e. the token stream looks like: `bound , bound ..`
+	 * Called after `[` is consumed, so LA(1) is the first token inside the brackets.
 	 */
 	private isSteppedRange(): boolean {
-		// At this point LA(1) is already consumed (we are inside rangeExpr after LBracket)
-		// Check if there's a Comma before the DotDot
+		// LA(1) is the first token after the consumed `[`.
+		// Scan forward until we find a Comma (stepped form) or DotDot/] (no-step form).
 		let i = 1;
 		while (i <= 15) {
 			const tok = this.LA(i).tokenType;

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -86,7 +86,9 @@ import {
 	DEDENT,
 	Utf8Kw,
 	LCurly,
-	RCurly
+	RCurly,
+	DotDot,
+	Comma
 } from './lexer.js';
 
 // ---------------------------------------------------------------------------
@@ -597,28 +599,174 @@ class FluxParser extends CstParser {
 	// sequenceGenerator — same body, but used inside a generatorExpr (nested)
 	// They are separate rules so the CST clearly labels which context a list
 	// appeared in.
+	//
+	// Both now support range notation as a first alternative, detected by
+	// scanning ahead for a DotDot token inside the brackets.
 	// -------------------------------------------------------------------------
 
+	/**
+	 * Lookahead predicate: returns true if the upcoming tokens look like a
+	 * range expression `[start..end]` or `[start, step..end]`.
+	 *
+	 * Scans forward from LA(1) (which must be `[`) for a `DotDot` token before
+	 * hitting `]` or end-of-input.
+	 */
+	private isRangeExpr(): boolean {
+		if (this.LA(1).tokenType !== LBracket) return false;
+		let i = 2;
+		// Scan up to 20 tokens ahead to find DotDot before ]
+		while (i <= 20) {
+			const tok = this.LA(i).tokenType;
+			if (tok === DotDot) return true;
+			if (tok === RBracket) return false;
+			// End-of-input sentinel has tokenTypeIdx === 0
+			if (this.LA(i).tokenTypeIdx === 0) return false;
+			i++;
+		}
+		return false;
+	}
+
 	sequenceExpr = this.RULE('sequenceExpr', () => {
+		this.OR([
+			{
+				GATE: () => this.isRangeExpr(),
+				ALT: () => this.SUBRULE(this.rangeExpr)
+			},
+			{
+				ALT: () => {
+					this.CONSUME(LBracket);
+					this.MANY(() => {
+						this.SUBRULE(this.sequenceElement);
+					});
+					this.CONSUME(RBracket);
+					this.MANY2(() => {
+						this.SUBRULE(this.modifierSuffix);
+					});
+				}
+			}
+		]);
+	});
+
+	sequenceGenerator = this.RULE('sequenceGenerator', () => {
+		this.OR([
+			{
+				GATE: () => this.isRangeExpr(),
+				ALT: () => this.SUBRULE(this.rangeExpr)
+			},
+			{
+				ALT: () => {
+					this.CONSUME(LBracket);
+					this.MANY(() => {
+						this.SUBRULE(this.sequenceElement);
+					});
+					this.CONSUME(RBracket);
+					this.MANY2(() => {
+						this.SUBRULE(this.modifierSuffix);
+					});
+				}
+			}
+		]);
+	});
+
+	/**
+	 * Range expression: `[start..end]` or `[start, step..end]`.
+	 *
+	 * Two syntactic forms:
+	 *
+	 *   rangeNoStep  = "[" intBound    ".." rangeBound "]" modifierSuffix*
+	 *   rangeWithStep = "[" rangeBound "," rangeBound ".." rangeBound "]" modifierSuffix*
+	 *
+	 * Float start WITHOUT an explicit step comma is a **parse error** — the grammar
+	 * only allows `rangeBound` (Float or Integer) as the start of the stepped form.
+	 * The no-step form uses `intBound` (Integer only, no Float).
+	 *
+	 * CST children (both forms share the same rangeExpr node):
+	 *   rangeBound[0]  — start bound
+	 *   Comma[0]       — present only in the stepped form
+	 *   rangeBound[1]  — step value (only when Comma is present)
+	 *   DotDot[0]      — the ".." separator
+	 *   rangeBound[N]  — end bound (index 1 in no-step form, 2 in stepped form)
+	 *
+	 * The evaluator enforces:
+	 *   - Zero step is a semantic error.
+	 *   - Step going the wrong direction is a semantic error.
+	 */
+	rangeExpr = this.RULE('rangeExpr', () => {
 		this.CONSUME(LBracket);
-		this.MANY(() => {
-			this.SUBRULE(this.sequenceElement);
-		});
+		this.OR([
+			// Stepped form: start, step..end (allows Float or Integer for all bounds)
+			{
+				GATE: () => this.isSteppedRange(),
+				ALT: () => {
+					this.SUBRULE(this.rangeBound); // start (Float or Integer)
+					this.CONSUME(Comma);
+					this.SUBRULE2(this.rangeBound); // step (Float or Integer)
+					this.CONSUME(DotDot);
+					this.SUBRULE3(this.rangeBound); // end (Float or Integer)
+				}
+			},
+			// No-step form: intStart..end (Integer only for start — Float is rejected)
+			{
+				ALT: () => {
+					this.SUBRULE(this.intBound); // Integer-only start
+					this.CONSUME2(DotDot);
+					this.SUBRULE4(this.rangeBound); // end (Integer)
+				}
+			}
+		]);
 		this.CONSUME(RBracket);
-		this.MANY2(() => {
+		this.MANY(() => {
 			this.SUBRULE(this.modifierSuffix);
 		});
 	});
 
-	sequenceGenerator = this.RULE('sequenceGenerator', () => {
-		this.CONSUME(LBracket);
-		this.MANY(() => {
-			this.SUBRULE(this.sequenceElement);
+	/**
+	 * Lookahead: returns true if inside a range bracket we see start, comma before DotDot.
+	 * i.e. the token stream after `[` looks like: `bound , bound ..`
+	 * We are already past LA(1)=`[`, so scan from LA(2).
+	 */
+	private isSteppedRange(): boolean {
+		// At this point LA(1) is already consumed (we are inside rangeExpr after LBracket)
+		// Check if there's a Comma before the DotDot
+		let i = 1;
+		while (i <= 15) {
+			const tok = this.LA(i).tokenType;
+			if (tok === Comma) return true;
+			if (tok === DotDot || tok === RBracket) return false;
+			if (this.LA(i).tokenTypeIdx === 0) return false;
+			i++;
+		}
+		return false;
+	}
+
+	/**
+	 * A numeric bound in a range expression: optional leading minus, then Float or Integer.
+	 *
+	 * CST children:
+	 *   Minus[0]   — present if negative
+	 *   Integer[0] — integer literal (if integer bound)
+	 *   Float[0]   — float literal (if float bound)
+	 */
+	rangeBound = this.RULE('rangeBound', () => {
+		this.OPTION(() => {
+			this.CONSUME(Minus);
 		});
-		this.CONSUME(RBracket);
-		this.MANY2(() => {
-			this.SUBRULE(this.modifierSuffix);
+		this.OR([{ ALT: () => this.CONSUME(Float) }, { ALT: () => this.CONSUME(Integer) }]);
+	});
+
+	/**
+	 * An integer-only bound for the no-step range form.
+	 * Float is not permitted here — use the stepped form `[f, step..end]` instead.
+	 *
+	 * CST children:
+	 *   Minus[0]   — present if negative
+	 *   Integer[0] — integer literal
+	 */
+	intBound = this.RULE('intBound', () => {
+		this.OPTION(() => {
+			this.CONSUME(Minus);
 		});
+		this.CONSUME(Integer);
 	});
 
 	sequenceElement = this.RULE('sequenceElement', () => {


### PR DESCRIPTION
## Summary

Implements SC-inspired compact range notation inside `[...]` sequence generators (issue #26).

- `[0..7]` expands to `[0 1 2 3 4 5 6 7]` — integer range, default step 1 (or -1 if descending)
- `[0, 2..10]` expands to `[0 2 4 6 8 10]` — explicit step (`second − first`)
- `[0.0, 0.25..1.0]` expands to `[0.0 0.25 0.5 0.75 1.0]` — float range with explicit step
- `[10, 8..0]` expands to `[10 8 6 4 2 0]` — descending
- Range lists support all usual modifiers: `[0..3]'shuf`, `[0..15]'pick`, etc.

## Design decisions

- **Eager expansion at compile time**: ranges expand to flat value arrays — they behave identically to an explicit element list.
- **Float without step is a parse error**: `[0.0..1.0]` is rejected at parse time; the grammar uses `intBound` (Integer-only) for the no-step form.
- **Zero step is a semantic error**: `[0, 0..5]` rejected with a clear message.
- **Overshooting step is a semantic error**: `[0, 2..1]` (step=2, end=1) rejected because the first step value already exceeds the end.
- **Float pattern fix**: added negative lookahead `(?!\.)` to the Float token so `0..7` lexes as `Integer DotDot Integer` rather than `Float(..) error`.

## Files changed

- `docs/DSL-spec.md` — new §Range notation subsection; updated whitespace rule note
- `docs/DSL-truthtables.md` — new truth table 22 (Range notation)
- `src/lib/lang/lexer.ts` — `DotDot`, `Comma` tokens; Float pattern fix
- `src/lib/lang/parser.ts` — `rangeExpr`, `rangeBound`, `intBound` rules; `isRangeExpr()` / `isSteppedRange()` predicates
- `src/lib/lang/evaluator.ts` — `expandRangeExpr()`, `rangeBoundToNumber()` helpers; range path in `compilePattern()` and `collectPatternModifiers()`
- `src/lib/lang/lexer.test.ts` — 10 new lexer tests
- `src/lib/lang/parser.test.ts` — 13 new parser tests
- `src/lib/lang/evaluator.test.ts` — 34 new evaluator tests

Closes #26