### PR TITLE
feat(DSL): Chord literal <d1 d2 ... dn> — simultaneous synths in one slot

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -511,7 +511,7 @@ mono lead [<1 2 3>]
 **Syntax:**
 
 ```ebnf
-chordLiteral    = "<" chordElement chordElement+ ">" ;
+chordLiteral    = "<" chordElement+ ">" ;
 chordElement    = numericGenerator | degreeLiteral | rest ;
 ```
 

--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -491,6 +491,40 @@ note lead [0 1 2] + 3        // → 3, 4, 5
 
 **Double-negative** — `note [0] - -4` is a parse error; use `note [0] + 4` instead. This restriction applies only to `+` and `-` because the leading `-` on the RHS is syntactically ambiguous with a negative number literal; for `*`, `/`, `**`, and `%` the RHS must always be a positive scalar or a list generator.
 
+### Chord literals
+
+> _See truth table [23 (Chord literals)](DSL-truthtables.md#23-chord-literals-truth-table)._
+
+`<d1 d2 ... dn>` denotes N simultaneous degree values in a single event slot, spawning N synths at the same time. Purely additive — no timing implications; all voices fire at the same beat offset.
+
+```flux
+// produces two chord events where chords are timed like [0 1]
+note chords [<0 2 4> <1 3 6>]
+
+// Generator in chord, produces chord events like [<0 6> 2], [<0 4> 2], etc.
+note chords [<0 4~7> 2]
+
+// Produces error message: "Chords are not supported for mono content type"
+mono lead [<1 2 3>]
+```
+
+**Syntax:**
+
+```ebnf
+chordLiteral    = "<" chordElement chordElement+ ">" ;
+chordElement    = numericGenerator | degreeLiteral | rest ;
+```
+
+- `<>` must contain at least one element; a bare `<>` with no elements is a parse error.
+- Elements inside `<>` are separated by spaces (same as `[...]`).
+- Each element is an independent generator evaluated at cycle boundary under standard `'eager` semantics.
+- A chord literal is a **non-scalar** generator — it is valid wherever a sequence element (`[...]`) or standalone event body is valid.
+
+**Constraints:**
+
+- **`<>` with `mono`:** Semantic error — multiple simultaneous `.set` messages with different degree values to the same node produce non-deterministic behaviour. Must be caught at evaluate time: `"Chords are not supported for mono content type"`.
+- **`<>` as transposition operand:** Parse error — `note [0 2 4] + <0 4>` would imply voice multiplication, not a chord. The transposition rule does not accept chord literals on the RHS.
+
 ### Accidentals
 
 > _See truth table [15 (Accidentals)](DSL-truthtables.md#15-accidentals-truth-table)._

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -507,3 +507,26 @@ Compact `[start..end]` / `[start, step..end]` syntax. All bounds inclusive. Eage
 | `[0.0..1.0]` | Parse error    | Float before `..` with no preceding comma (no explicit step); step would be fractional and unknown. |
 | `[0, 0..5]`  | Semantic error | Step of zero produces an infinite loop; rejected at compile time.                                   |
 | `[0, 2..1]`  | Semantic error | Step (2) goes the wrong direction relative to end (1), so no elements would be produced.            |
+
+---
+
+# 23. **Chord Literals Truth Table**
+
+`<d1 d2 ... dn>` — N simultaneous degree values in one event slot. Spawns N synths at the same beat offset.
+
+| Code Snippet                   | Interpretation                            | Evaluation                                                                 | Result                                                    |
+| ------------------------------ | ----------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `note x [<0 2 4>]`             | Single chord slot — triad.                | Three NoteEvents at the same beatOffset.                                   | Three simultaneous notes (MIDI 60, 64, 67 in C major/C5). |
+| `note x [<0 2 4> <1 3 6>]`     | Two chord slots, each a triad.            | Cycle: two slots; each produces three NoteEvents.                          | Chords timed like a 2-element list.                       |
+| `note x [<0 4~7> 2]`           | Chord with a generator element.           | `4~7` polled at cycle boundary (`'eager(1)`); degree 2 is the second slot. | First slot: chord (0, random 4–7); second slot: degree 2. |
+| `note x [0 <2 4> 7]`           | Mixed: scalars and chord inside one list. | Three slots; middle slot emits two simultaneous notes.                     | Slot 0: one note; slot 1: two notes; slot 2: one note.    |
+| `@scale(minor) note x [<0 2>]` | Chord in non-default scale context.       | Degrees resolved under minor scale.                                        | Two notes at minor-scale MIDI values for degrees 0 and 2. |
+| `note x [<0 2>]'legato(1.2)`   | Legato applied to chord.                  | Legato applies uniformly to all voices in the chord.                       | Both notes have `duration = slot × 1.2`.                  |
+
+**Error cases**
+
+| Code                 | Failure Type   | Why                                                                            |
+| -------------------- | -------------- | ------------------------------------------------------------------------------ |
+| `mono x [<0 2 4>]`   | Semantic error | Chords are not supported for mono content type.                                |
+| `note x [0] + <0 4>` | Parse error    | Chord literal is not valid as a transposition operand; the grammar rejects it. |
+| `note x [<>]`        | Parse error    | Empty chord — at least one element is required.                                |

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -2784,3 +2784,93 @@ describe('range notation — nested inside outer list', () => {
 		expect(evs).toHaveLength(5);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 23. Chord literals <> — truth table
+// ---------------------------------------------------------------------------
+
+describe('chord literals — basic', () => {
+	it('note x [<0 2 4>] — single chord slot produces 3 simultaneous NoteEvents', () => {
+		const evs = eval0('note x [<0 2 4>]');
+		// Triad in C major/C5: C5=60, E5=64, G5=67
+		expect(evs).toHaveLength(3);
+		const sortedNotes = evs.map((e) => pitched(e).note).sort((a, b) => a - b);
+		expect(sortedNotes).toEqual([60, 64, 67]);
+	});
+
+	it('all chord voices share the same beatOffset', () => {
+		const evs = eval0('note x [<0 2 4>]');
+		expect(evs).toHaveLength(3);
+		const offsets = evs.map((e) => e.beatOffset);
+		expect(offsets[0]).toBe(offsets[1]);
+		expect(offsets[1]).toBe(offsets[2]);
+	});
+
+	it('note x [<0 2 4> <1 3 6>] — two chord slots, 6 total events', () => {
+		const evs = eval0('note x [<0 2 4> <1 3 6>]');
+		// 2 slots × 3 voices = 6 events
+		expect(evs).toHaveLength(6);
+	});
+
+	it('two chord slots have different beatOffsets', () => {
+		const evs = eval0('note x [<0 2 4> <1 3 6>]');
+		// First chord at beatOffset 0, second at beatOffset 0.5
+		const offsets = [...new Set(evs.map((e) => e.beatOffset))].sort((a, b) => a - b);
+		expect(offsets).toHaveLength(2);
+		expect(offsets[0]).toBeCloseTo(0);
+		expect(offsets[1]).toBeCloseTo(0.5);
+	});
+
+	it('note x [0 <2 4> 7] — mixed scalars and chord: 4 total events', () => {
+		const evs = eval0('note x [0 <2 4> 7]');
+		// 3 slots: slot 0 = 1 event, slot 1 = 2 events, slot 2 = 1 event
+		expect(evs).toHaveLength(4);
+	});
+
+	it('chord slot duration equals 1/n where n = number of top-level slots', () => {
+		// note x [<0 2>] — 1 top-level slot, duration = 1.0 * legato (0.8)
+		const evs = eval0('note x [<0 2>]');
+		expect(evs).toHaveLength(2);
+		// Each voice duration = 1/1 * 0.8 = 0.8
+		expect(evs[0].duration).toBeCloseTo(0.8);
+		expect(evs[1].duration).toBeCloseTo(0.8);
+	});
+
+	it("note x [<0 2 4>]'legato(1.2) — legato applies to all chord voices", () => {
+		const evs = eval0("note x [<0 2 4>]'legato(1.2)");
+		expect(evs).toHaveLength(3);
+		for (const ev of evs) {
+			expect(ev.duration).toBeCloseTo(1.2);
+		}
+	});
+});
+
+describe('chord literals — scale context', () => {
+	it('@scale(minor) note x [<0 2>] — voices resolved under minor scale', () => {
+		const evs = eval0('@scale(minor) note x [<0 2>]');
+		expect(evs).toHaveLength(2);
+		// C minor/C5: degree 0 = C5 = 60, degree 2 = Eb5 = 63
+		const sortedNotes = evs.map((e) => pitched(e).note).sort((a, b) => a - b);
+		expect(sortedNotes).toEqual([60, 63]);
+	});
+});
+
+describe('chord literals — error cases', () => {
+	it('mono x [<0 2 4>] — semantic error: chords not supported for mono', () => {
+		const i = createInstance('mono x [<0 2 4>]');
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('chord');
+		}
+	});
+
+	it('note x [0] + <0 4> — parse error: chord literal not valid as transposition operand', () => {
+		const i = createInstance('note x [0] + <0 4>');
+		expect(i.ok).toBe(false);
+	});
+
+	it('note x [<>] — parse error: empty chord', () => {
+		const i = createInstance('note x [<>]');
+		expect(i.ok).toBe(false);
+	});
+});

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -2873,4 +2873,12 @@ describe('chord literals — error cases', () => {
 		const i = createInstance('note x [<>]');
 		expect(i.ok).toBe(false);
 	});
+
+	it('mono x [[<0 2>]] — chord nested inside subsequence is also a semantic error', () => {
+		const i = createInstance('mono x [[<0 2>]]');
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('chord');
+		}
+	});
 });

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -686,7 +686,25 @@ type CompiledSymbol = {
 	beatOverride?: number;
 };
 
-type CompiledElement = CompiledScalar | CompiledSubsequence | CompiledRest | CompiledSymbol;
+/**
+ * A chord literal `<d1 d2 ... dn>` — N simultaneous degrees in one event slot.
+ * All voices share the same beat offset and duration.
+ * Each voice is a scalar runner (compiled independently).
+ */
+type CompiledChord = {
+	kind: 'chord';
+	/** One runner per chord voice, in order. */
+	voices: Array<{ runner: RunnerState; accidentalOffset: number }>;
+	/** Per-element weight for parent 'pick selection (default: 1). */
+	weight: RunnerState;
+};
+
+type CompiledElement =
+	| CompiledScalar
+	| CompiledSubsequence
+	| CompiledRest
+	| CompiledSymbol
+	| CompiledChord;
 
 /**
  * Read the `!n` inline-repetition count from a sequenceElement CST node.
@@ -737,6 +755,12 @@ function compileElement(elem: CstNode, inherited: EagerMode): CompiledElement | 
 		const poll: PollFn = () => degree;
 		const weight = makeRunner(() => 1, { kind: 'lock' });
 		return { kind: 'scalar', runner: makeRunner(poll, inherited), accidentalOffset, weight };
+	}
+
+	// Check for chord literal: <d1 d2 ... dn>
+	const chordLitNode = ((elem.children.chordLiteral as CstNode[]) ?? [])[0];
+	if (chordLitNode) {
+		return compileChordLiteral(chordLitNode, inherited);
 	}
 
 	// Element-level modifiers come from the generatorExpr's modifierSuffix children.
@@ -829,6 +853,75 @@ function compileElement(elem: CstNode, inherited: EagerMode): CompiledElement | 
 	const weight = weightFromElem(elem);
 
 	return { kind: 'scalar', runner: makeRunner(poll, effectiveMode), accidentalOffset, weight };
+}
+
+/**
+ * Compile a chordLiteral CST node into a CompiledChord.
+ * Each chordElement becomes one voice (scalar runner).
+ */
+function compileChordLiteral(chordNode: CstNode, inherited: EagerMode): CompiledChord | null {
+	const chordElements = (chordNode.children.chordElement as CstNode[]) ?? [];
+	if (chordElements.length === 0) return null;
+
+	const voices: Array<{ runner: RunnerState; accidentalOffset: number }> = [];
+
+	for (const ce of chordElements) {
+		// Rest inside chord: skip (a rest voice contributes no sound but is valid syntax)
+		const restToks = (ce.children.Rest as IToken[]) ?? [];
+		if (restToks.length > 0) continue;
+
+		let accidentalOffset = 0;
+
+		// degreeLiteral: integer with optional accidental
+		const degreeLitNode = ((ce.children.degreeLiteral as CstNode[]) ?? [])[0];
+		if (degreeLitNode) {
+			const intTok = ((degreeLitNode.children.Integer as IToken[]) ?? [])[0];
+			if (!intTok) continue;
+			const degree = parseInt(intTok.image, 10);
+			const sharps = (degreeLitNode.children.Sharp as IToken[]) ?? [];
+			const flats = (degreeLitNode.children.Flat as IToken[]) ?? [];
+			accidentalOffset += sharps.length;
+			for (const f of flats) accidentalOffset -= f.image.length;
+			const poll: PollFn = () => degree;
+			voices.push({ runner: makeRunner(poll, inherited), accidentalOffset });
+			continue;
+		}
+
+		// generatorExpr
+		const genExpr = ((ce.children.generatorExpr as CstNode[]) ?? [])[0];
+		if (!genExpr) continue;
+
+		const elemMods = (genExpr.children.modifierSuffix as CstNode[]) ?? [];
+		const elemMode = extractEagerMode(elemMods);
+		const effectiveMode: EagerMode = elemMode ?? inherited;
+
+		const atomic = ((genExpr.children.atomicGenerator as CstNode[]) ?? [])[0];
+		if (!atomic) continue;
+
+		// utf8Generator as chord element
+		const utf8Gen = ((atomic.children.utf8Generator as CstNode[]) ?? [])[0];
+		if (utf8Gen) {
+			const poll = utf8GenToPollFn(utf8Gen);
+			if (!poll) continue;
+			voices.push({ runner: makeRunner(poll, effectiveMode), accidentalOffset: 0 });
+			continue;
+		}
+
+		// numericGenerator
+		const numGen = ((atomic.children.numericGenerator as CstNode[]) ?? [])[0];
+		if (!numGen) continue;
+		const poll = numGenToPollFn(numGen);
+		if (!poll) continue;
+		voices.push({ runner: makeRunner(poll, effectiveMode), accidentalOffset: 0 });
+	}
+
+	if (voices.length === 0) return null;
+
+	return {
+		kind: 'chord',
+		voices,
+		weight: makeRunner(() => 1, { kind: 'lock' })
+	};
 }
 
 /**
@@ -1529,6 +1622,13 @@ function compilePattern(
 	const isCloud = ((patternNode.children.Cloud as IToken[]) ?? [])[0] !== undefined;
 	if (compiled.length === 0 && !isCloud) return 'pattern sequence is empty';
 
+	// Semantic error: chord literals are not valid in mono content type.
+	// Check for any chord element in the compiled sequence.
+	const isMono = ((patternNode.children.Mono as IToken[]) ?? [])[0] !== undefined;
+	if (isMono && compiled.some((el) => el.kind === 'chord')) {
+		return 'Chords are not supported for mono content type';
+	}
+
 	// Pattern-level modifiers (direct + continuation)
 	const allMods = collectPatternModifiers(patternNode);
 
@@ -1867,6 +1967,22 @@ function expandSlot(
 		if (p.synthdef !== null) ev.synthdef = p.synthdef;
 		if (p.noteParams !== undefined) ev.params = p.noteParams;
 		return [ev];
+	}
+
+	if (el.kind === 'chord') {
+		// Chord literal: N simultaneous notes, all sharing the same beat offset and duration.
+		// Each voice is evaluated independently as a scalar element at the same slot.
+		const out: ScheduledEvent[] = [];
+		for (const voice of el.voices) {
+			const syntheticScalar: CompiledScalar = {
+				kind: 'scalar',
+				runner: voice.runner,
+				accidentalOffset: voice.accidentalOffset,
+				weight: el.weight
+			};
+			out.push(...expandSlot(syntheticScalar, slotStart, slotDuration, p));
+		}
+		return out;
 	}
 
 	// scalar — pitch-bearing element for note, mono, slice
@@ -2239,10 +2355,11 @@ function compileSource(source: string): CompileResult {
 			const parentName = isDerived ? (genNameToks[1]?.image ?? null) : null;
 			const parent = parentName ? compiledByName.get(parentName) : undefined;
 			const compiled = compilePattern(node, parent);
-			if (typeof compiled !== 'string') {
-				compiledByName.set(compiled.name, compiled);
-				patternEntries.push({ kind: 'plain', compiled });
+			if (typeof compiled === 'string') {
+				return { ok: false, error: `Semantic error: ${compiled}` };
 			}
+			compiledByName.set(compiled.name, compiled);
+			patternEntries.push({ kind: 'plain', compiled });
 		}
 	}
 

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -1516,6 +1516,18 @@ function extractBufName(decoratorLayers: CstNode[][]): string | null {
 	return null;
 }
 
+/**
+ * Returns true if any element in the list (or recursively in nested subsequences)
+ * is a CompiledChord. Used to enforce the mono + chord semantic error.
+ */
+function hasChordElement(elements: CompiledElement[]): boolean {
+	for (const el of elements) {
+		if (el.kind === 'chord') return true;
+		if (el.kind === 'sequence' && hasChordElement(el.elements)) return true;
+	}
+	return false;
+}
+
 function compilePattern(
 	patternNode: CstNode,
 	parentPattern?: CompiledPattern,
@@ -1623,9 +1635,9 @@ function compilePattern(
 	if (compiled.length === 0 && !isCloud) return 'pattern sequence is empty';
 
 	// Semantic error: chord literals are not valid in mono content type.
-	// Check for any chord element in the compiled sequence.
+	// Check recursively for any chord element in the compiled sequence (including nested subsequences).
 	const isMono = ((patternNode.children.Mono as IToken[]) ?? [])[0] !== undefined;
-	if (isMono && compiled.some((el) => el.kind === 'chord')) {
+	if (isMono && hasChordElement(compiled)) {
 		return 'Chords are not supported for mono content type';
 	}
 

--- a/src/lib/lang/lexer.test.ts
+++ b/src/lib/lang/lexer.test.ts
@@ -41,7 +41,9 @@ import {
 	LCurly,
 	RCurly,
 	DotDot,
-	Comma
+	Comma,
+	LAngle,
+	RAngle
 } from './lexer.js';
 
 describe('FluxLexer', () => {
@@ -783,5 +785,31 @@ describe('Comma — range-specific separator token', () => {
 		expect(commaIdx).toBeGreaterThan(0);
 		expect(tokens[commaIdx - 1].tokenType).toBe(Integer);
 		expect(tokens[commaIdx + 1].tokenType).toBe(Integer);
+	});
+});
+
+describe('LAngle / RAngle — chord literal delimiters', () => {
+	it('tokenizes "<" as LAngle', () => {
+		const { tokens, errors } = FluxLexer.tokenize('<');
+		expect(errors).toHaveLength(0);
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].tokenType).toBe(LAngle);
+	});
+
+	it('tokenizes ">" as RAngle', () => {
+		const { tokens, errors } = FluxLexer.tokenize('>');
+		expect(errors).toHaveLength(0);
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].tokenType).toBe(RAngle);
+	});
+
+	it('tokenizes "<0 2 4>" as LAngle Integer Integer Integer RAngle', () => {
+		const { tokens, errors } = FluxLexer.tokenize('<0 2 4>');
+		expect(errors).toHaveLength(0);
+		expect(tokens[0].tokenType).toBe(LAngle);
+		expect(tokens[1].tokenType).toBe(Integer);
+		expect(tokens[2].tokenType).toBe(Integer);
+		expect(tokens[3].tokenType).toBe(Integer);
+		expect(tokens[4].tokenType).toBe(RAngle);
 	});
 });

--- a/src/lib/lang/lexer.ts
+++ b/src/lib/lang/lexer.ts
@@ -593,6 +593,20 @@ export const DotDot = createToken({
 	// Monaco scope: 'operator'
 });
 
+/** `<` — opens a chord literal: `<0 2 4>`. */
+export const LAngle = createToken({
+	name: 'LAngle',
+	pattern: /</
+	// Monaco scope: 'delimiter.bracket'
+});
+
+/** `>` — closes a chord literal: `<0 2 4>`. */
+export const RAngle = createToken({
+	name: 'RAngle',
+	pattern: />/
+	// Monaco scope: 'delimiter.bracket'
+});
+
 /**
  * `,` — range-step separator: `[0, 2..10]`.
  * Only meaningful inside a range expression; the parser treats a bare `,`
@@ -782,6 +796,9 @@ export const allTokens = [
 	// Range operators — DotDot before Float so '..' is not eaten by the Float pattern
 	DotDot, // '..' — range separator
 	Comma, // ',' — range step separator
+	// Chord literal delimiters
+	LAngle, // '<' — opens chord literal
+	RAngle, // '>' — closes chord literal
 	// Literals — Float before Integer
 	Float,
 	Integer,

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -905,3 +905,45 @@ describe('range notation — parser', () => {
 		expect(parseErrors.length + lexErrors.length).toBeGreaterThan(0);
 	});
 });
+
+describe('chord literals <>', () => {
+	it('parses a chord inside a sequence list', () => {
+		const { parseErrors, lexErrors } = parse('note x [<0 2 4>]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses two chord slots in a list', () => {
+		const { parseErrors, lexErrors } = parse('note chords [<0 2 4> <1 3 6>]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses chord with generator element inside', () => {
+		const { parseErrors, lexErrors } = parse('note x [<0 4~7> 2]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses mixed scalar and chord in a list', () => {
+		const { parseErrors, lexErrors } = parse('note x [0 <2 4> 7]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses chord with mono keyword (semantic check is in evaluator)', () => {
+		const { parseErrors, lexErrors } = parse('mono x [<0 2 4>]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('rejects chord literal as transposition operand — parse error', () => {
+		const { parseErrors, lexErrors } = parse('note x [0 2 4] + <0 4>');
+		expect(parseErrors.length + lexErrors.length).toBeGreaterThan(0);
+	});
+
+	it('rejects empty chord — parse error', () => {
+		const { parseErrors, lexErrors } = parse('note x [<>]');
+		expect(parseErrors.length + lexErrors.length).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -88,7 +88,9 @@ import {
 	LCurly,
 	RCurly,
 	DotDot,
-	Comma
+	Comma,
+	LAngle,
+	RAngle
 } from './lexer.js';
 
 // ---------------------------------------------------------------------------
@@ -771,8 +773,8 @@ class FluxParser extends CstParser {
 
 	sequenceElement = this.RULE('sequenceElement', () => {
 		// A degree literal (possibly with accidentals), a rest (_), a \symbol buffer ref,
-		// or a generator expression, with an optional `?weight` for 'wran lists and an
-		// optional `!n` repeat count.
+		// a chord literal (<d1 d2 ... dn>), or a generator expression, with an optional
+		// `?weight` for 'wran lists and an optional `!n` repeat count.
 		this.OR([
 			// rest: a silent slot — no pitch, no synth
 			{ ALT: () => this.CONSUME(Rest) },
@@ -780,6 +782,11 @@ class FluxParser extends CstParser {
 			{
 				GATE: () => this.hasDegreeAccidental(),
 				ALT: () => this.SUBRULE(this.degreeLiteral)
+			},
+			// chord literal: <d1 d2 ... dn> — N simultaneous degrees
+			{
+				GATE: () => this.LA(1).tokenType === LAngle,
+				ALT: () => this.SUBRULE(this.chordLiteral)
 			},
 			// \symbol buffer ref — for sample lists [\kick \hat \snare]
 			{ ALT: () => this.CONSUME(Symbol) },
@@ -795,6 +802,46 @@ class FluxParser extends CstParser {
 			this.CONSUME(Bang);
 			this.CONSUME(Integer);
 		});
+	});
+
+	/**
+	 * Chord literal: `<d1 d2 ... dn>` — N simultaneous degree values in one slot.
+	 *
+	 * Elements are the same as sequenceElement but without nesting (no chord inside chord).
+	 * Each element is an independent generator; modifiers are not valid on the chord itself
+	 * (use list-level modifiers instead).
+	 *
+	 * At least one element is required. An empty `<>` is a parse error.
+	 *
+	 * CST children:
+	 *   - LAngle[0]          — `<`
+	 *   - chordElement[]     — one or more chord elements
+	 *   - RAngle[0]          — `>`
+	 */
+	chordLiteral = this.RULE('chordLiteral', () => {
+		this.CONSUME(LAngle);
+		this.AT_LEAST_ONE(() => {
+			this.SUBRULE(this.chordElement);
+		});
+		this.CONSUME(RAngle);
+	});
+
+	/**
+	 * A single element inside a chord literal.
+	 * Accepts: rest, degreeLiteral, or a generator expression (including utf8, numeric).
+	 * Does NOT accept nested chord literals or \symbol buffer refs (those are not meaningful in chord position).
+	 *
+	 * CST children are the same shape as sequenceElement children.
+	 */
+	chordElement = this.RULE('chordElement', () => {
+		this.OR([
+			{ ALT: () => this.CONSUME(Rest) },
+			{
+				GATE: () => this.hasDegreeAccidental(),
+				ALT: () => this.SUBRULE(this.degreeLiteral)
+			},
+			{ ALT: () => this.SUBRULE(this.generatorExpr) }
+		]);
 	});
 
 	/**


### PR DESCRIPTION
## Summary

- Adds `<d1 d2 ... dn>` chord literal syntax: N simultaneous degree values in a single event slot, spawning N synths at the same beat offset
- Generators inside `<>` are supported; each element is an independent runner evaluated under standard `'eager` semantics
- Semantic error: `<>` inside a `mono` pattern raises `"Chords are not supported for mono content type"`
- Parse error: `<>` as transposition operand (`note [0] + <0 4>`) is rejected by the grammar
- Also fixes a silent bug: `compilePattern` string errors were previously discarded silently, causing confusing "no pattern statement found" messages instead of the real error

## Test plan

- [ ] `pnpm vitest run src/lib/lang/lexer.test.ts` — LAngle/RAngle tokens
- [ ] `pnpm vitest run src/lib/lang/parser.test.ts` — chord literal parser rules
- [ ] `pnpm vitest run src/lib/lang/evaluator.test.ts` — truth table cases: basic chords, scale context, error cases
- [ ] `pnpm check` — type-check clean
- [ ] `pnpm vitest run --project=server` — all 886 server tests pass

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)