### PR TITLE
feat(DSL): 'arp modifier — arpeggiation from cycle output

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -48,6 +48,8 @@ Inside `[...]` sequence generators, elements are separated by spaces. Commas are
 [1 2 3]'shuf       // shuffle then traverse, like Pshuf
 [1 2 3]'pick       // uniform random element each time, like Prand
 [1 2?2 3]'pick     // weighted random — like Pwrand with weights 1/2/1
+[0..10]'arp        // arpeggiate ascending (default \up)
+[0..10]'arp(\down) // arpeggiate descending
 ```
 
 `'pick` supports optional per-element weights via the `?` operator. Unweighted elements default to weight 1; when no weights are present, `'pick` is uniform random. When any weights are present, selection is proportional to the weights (normalised to sum to 1).
@@ -57,6 +59,55 @@ Inside `[...]` sequence generators, elements are separated by spaces. Commas are
 - Negative weights (e.g. `?-1`) are a parse error.
 - Generator expressions are not valid as weights — `?` must be followed by a numeric literal.
 - The `?` weight syntax is only meaningful on a list whose own modifiers include `'pick`. Using `?` on a list without `'pick` is not an error, but the weight is ignored and a warning is logged. This rule applies per list level: `[[1 2?3]'pick 5]` is fine, but `[[1 2?3] 5]'pick` ignores the inner `?3` because the inner list has no `'pick`.
+
+### Arpeggiation (`'arp`)
+
+> _See truth table [25 (`'arp`)](DSL-truthtables.md#25-arp-truth-table)._
+
+`'arp` is a **list-level modifier** that collects the cycle's output values, removes duplicates, and traverses them in a melodic pattern. Syntax:
+
+```flux
+[0..10]'arp                    // default \up algorithm — sorted ascending
+[0..10]'arp(\down)             // sorted descending
+[0..10]'arp(\updown)           // palindrome, no repeated endpoints
+[0..10]'arp(\down 16)          // \down traversal cycled to 16 values
+[0 5 2 7 3]'arp(\inward)       // pincer from outer to inner
+```
+
+**Grammar:** `'arp` | `'arp(\symbol)` | `'arp(\symbol integer)`
+
+**Algorithms:**
+
+| Symbol      | Traversal                                                      |
+| ----------- | -------------------------------------------------------------- |
+| `\up`       | Sorted ascending (default)                                     |
+| `\down`     | Sorted descending                                              |
+| `\inward`   | Pincer from both ends toward middle                            |
+| `\outward`  | Starts at middle, expands outward (reverse of `\inward`)       |
+| `\updown`   | Ascending then descending palindrome; natural length = 2×(N−1) |
+| `\converge` | Alias for `\inward`                                            |
+| `\diverge`  | Alias for `\outward`                                           |
+
+**Duplicate removal:** before arpeggiation, numeric values are deduplicated by equality, preserving the order of first occurrence. This applies after all rests are filtered out.
+
+**Rests:** rest elements in the list are filtered out before deduplication and arpeggiation. If all elements are rests, the cycle yields a single rest event.
+
+**Single-element input:** `'arp` is a no-op — yields that single value as the one cycle slot.
+
+**Default output length** equals the natural traversal length for the chosen algorithm. For `\up`, `\down`, `\inward`, `\outward`, `\converge`, `\diverge` the natural length equals the deduped input length N. For `\updown` the natural length is 2×(N−1).
+
+**Length override** `'arp(\symbol n)`: cycles the natural traversal to produce exactly `n` values. `n = 0` or negative is a semantic error.
+
+**Even-length center for `\inward`/`\outward`:** for deduped input of length 2k (even), `\inward` pairs outer→inner: `a0, a(2k-1), a1, a(2k-2), ...` ending at the two middle elements `a(k-1), ak`. `\outward` is the reverse.
+
+**Semantic errors:**
+
+- `'arp` on a scalar element inside a list (e.g. `[0rand7'arp]`) — attach to the list instead: `[0rand7]'arp`
+- `'arp` combined with `'shuf` or `'pick` — choose one traversal strategy
+- Unknown algorithm symbol
+- Length override ≤ 0
+
+**Composition:** `'arp` composes with other list-level modifiers (`'stut`, `'lock`, `'eager`). `'arp` applies first (generates the traversal), then other modifiers operate on the resulting sequence.
 
 ### Range notation
 

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -587,3 +587,72 @@ Compact `[start..end]` / `[start, step..end]` syntax. All bounds inclusive. Eage
 | `note x [0step1x4'spread(-1)]`     | Semantic error | Negative count is not meaningful.                                                                                                                                                                |
 | `note x [0step1x4'spread([1 2])]`  | Semantic error | Count argument must be a scalar generator, not a list.                                                                                                                                           |
 | `note x [0step1x4'stut(2)'spread]` | Semantic error | `'stut` and `'spread` on the same element are ambiguous. Use list-level `'stut` instead: `[0step1x4'spread]'stut(2)`.                                                                            |
+
+---
+
+# 25. **`'arp` Truth Table**
+
+`'arp` collects a list's cycle output, removes duplicate numeric values (preserving order of first occurrence), filters rests, and traverses the result via the chosen algorithm.
+
+**Canonical input:** `[0..10]` = `[0 1 2 3 4 5 6 7 8 9 10]` (11 elements, N=11, odd).
+Default pitch context: C major / C5. Degree → MIDI: 0→60, 1→62, 2→64, 3→65, 4→67, 5→69, 6→71, 7→72, 8→74, 9→76, 10→77.
+
+## Algorithm rows — canonical input `[0..10]`
+
+| Code Snippet                    | Algorithm       | Output (degrees)                           | Output length | Notes                                                           |
+| ------------------------------- | --------------- | ------------------------------------------ | ------------- | --------------------------------------------------------------- |
+| `note x [0..10]'arp`            | `\up` (default) | `0 1 2 3 4 5 6 7 8 9 10`                   | 11            | Sorted ascending                                                |
+| `note x [0..10]'arp(\up)`       | `\up`           | `0 1 2 3 4 5 6 7 8 9 10`                   | 11            | Explicit; same as bare `'arp`                                   |
+| `note x [0..10]'arp(\down)`     | `\down`         | `10 9 8 7 6 5 4 3 2 1 0`                   | 11            | Sorted descending                                               |
+| `note x [0..10]'arp(\inward)`   | `\inward`       | `0 10 1 9 2 8 3 7 4 6 5`                   | 11            | Pincer outer→inner; odd N ends on single middle                 |
+| `note x [0..10]'arp(\outward)`  | `\outward`      | `5 6 4 7 3 8 2 9 1 10 0`                   | 11            | Reverse of `\inward`                                            |
+| `note x [0..10]'arp(\updown)`   | `\updown`       | `0 1 2 3 4 5 6 7 8 9 10 9 8 7 6 5 4 3 2 1` | 20            | Palindrome; **default length = 2×(N−1)**; no repeated endpoints |
+| `note x [0..10]'arp(\converge)` | `\converge`     | same as `\inward`                          | 11            | Alias for `\inward`                                             |
+| `note x [0..10]'arp(\diverge)`  | `\diverge`      | same as `\outward`                         | 11            | Alias for `\outward`                                            |
+
+## Even-length input — `[0..9]` (N=10)
+
+| Code Snippet                  | Algorithm  | Output (degrees)      | Notes                                             |
+| ----------------------------- | ---------- | --------------------- | ------------------------------------------------- |
+| `note x [0..9]'arp(\inward)`  | `\inward`  | `0 9 1 8 2 7 3 6 4 5` | Even N: ends on the two middle elements as a pair |
+| `note x [0..9]'arp(\outward)` | `\outward` | `5 4 6 3 7 2 8 1 9 0` | Reverse of `\inward`; starts with middle pair     |
+
+## Length override
+
+| Code Snippet                    | Output                              | Notes                               |
+| ------------------------------- | ----------------------------------- | ----------------------------------- |
+| `note x [0..10]'arp(\down 16)`  | `10 9 8 7 6 5 4 3 2 1 0 10 9 8 7 6` | 16 values cycling `\down` traversal |
+| `note x [0..10]'arp(\up 5)`     | `0 1 2 3 4`                         | First 5 values of `\up`             |
+| `note x [0..10]'arp(\updown 5)` | `0 1 2 3 4`                         | First 5 values of updown traversal  |
+
+## Duplicate removal
+
+| Code Snippet                      | Deduped input                        | Output    | Notes                                      |
+| --------------------------------- | ------------------------------------ | --------- | ------------------------------------------ |
+| `note x [5 3 7 3 1]'arp`          | `[5 3 7 1]` (first-occurrence order) | `1 3 5 7` | `\up` sorts numerically; dedup before sort |
+| `note x [5 3 7 3 1]'arp(\inward)` | `[5 3 7 1]` → sorted `[1 3 5 7]`     | `1 7 3 5` | Sort, then inward on deduplicated input    |
+
+## Rests and edge cases
+
+| Code Snippet             | Result                | Notes                                       |
+| ------------------------ | --------------------- | ------------------------------------------- |
+| `note x [0 _ 4 _ 8]'arp` | `[0 4 8]` arpeggiated | Rests filtered before arpeggiation          |
+| `note x [_ _ _]'arp`     | One rest event        | All-rest input → single rest (silent cycle) |
+| `note x [4]'arp`         | `[4]` (one event)     | Single element → no-op                      |
+
+## Composition
+
+| Code Snippet                | Result   | Notes                                                        |
+| --------------------------- | -------- | ------------------------------------------------------------ |
+| `note x [0..3]'arp'stut(2)` | 8 events | `'arp` produces 4-element traversal; `'stut(2)` doubles each |
+
+## Error cases
+
+| Code Snippet                | Failure Type   | Why                                                                               |
+| --------------------------- | -------------- | --------------------------------------------------------------------------------- |
+| `note x [0rand7'arp]`       | Semantic error | `'arp` is list-level — attach to the `[...]` list, not to a scalar element inside |
+| `note x [0..5]'arp'shuf`    | Semantic error | Cannot combine `'arp` with `'shuf` — choose one traversal strategy                |
+| `note x [0..5]'arp'pick`    | Semantic error | Cannot combine `'arp` with `'pick` — choose one traversal strategy                |
+| `note x [0..5]'arp(\bogus)` | Semantic error | Unknown algorithm symbol                                                          |
+| `note x [0..5]'arp(\up 0)`  | Semantic error | Length override must be a positive integer ≥ 1                                    |
+| `note x [0..5]'arp(\up -3)` | Semantic error | Negative length override is not meaningful                                        |

--- a/src/lib/lang/completions.ts
+++ b/src/lib/lang/completions.ts
@@ -143,6 +143,32 @@ const MODIFIER_COMPLETIONS: CompletionItem[] = [
 		kind: 'keyword'
 	},
 	{
+		label: 'arp',
+		insertText: 'arp',
+		detail: "'arp — arpeggiate list values (default \\up)",
+		documentation:
+			"Collects cycle output, removes duplicates, and traverses in a pattern. Algorithms: \\up, \\down, \\inward, \\outward, \\updown, \\converge, \\diverge. Use 'arp(\\algorithm n) for a length override.",
+		kind: 'keyword'
+	},
+	{
+		label: 'arp(algorithm)',
+		insertText: 'arp(\\${1:up})',
+		isSnippet: true,
+		detail: "'arp(algorithm) — arpeggiate with explicit algorithm",
+		documentation:
+			'Algorithms: \\up (default), \\down, \\inward, \\outward, \\updown, \\converge (alias \\inward), \\diverge (alias \\outward).',
+		kind: 'snippet'
+	},
+	{
+		label: 'arp(algorithm n)',
+		insertText: 'arp(\\${1:down} ${2:16})',
+		isSnippet: true,
+		detail: "'arp(algorithm n) — arpeggiate with length override",
+		documentation:
+			'Produces exactly n values by cycling the natural traversal. n must be a positive integer ≥ 1.',
+		kind: 'snippet'
+	},
+	{
 		label: 'tail(s)',
 		insertText: 'tail(${1:4})',
 		isSnippet: true,

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -3303,4 +3303,13 @@ describe("'arp — arpeggiation modifier (truth table 25)", () => {
 		if (!r0.ok || !r1.ok) throw new Error('eval failed');
 		expect(r0.events.map((e) => pitched(e).note)).toEqual(r1.events.map((e) => pitched(e).note));
 	});
+
+	// Truth table row: dedup + \inward
+	// [5 3 7 3 1] → deduped = [5 3 7 1] (first-occurrence order)
+	// sorted = [1 3 5 7], then \inward: a0=1, a3=7, a1=3, a2=5 → [1, 7, 3, 5]
+	// degrees: 1→62, 7→72, 3→65, 5→69
+	it("dedup + \\inward: [5 3 7 3 1]'arp(\\inward) — sort deduplicated then inward", () => {
+		const ns = arpNotes("note x [5 3 7 3 1]'arp(\\inward)");
+		expect(ns).toEqual([62, 72, 65, 69]);
+	});
 });

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -3067,3 +3067,240 @@ describe("'spread error cases", () => {
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 13. 'arp modifier — arpeggiation from cycle output (truth table 25)
+// ---------------------------------------------------------------------------
+//
+// Input [0..10] = [0 1 2 3 4 5 6 7 8 9 10] (11 elements, deduped = same)
+// Default C major, C5 context. Degree → MIDI: 0→60, 1→62, 2→64, 3→65, 4→67,
+//   5→69, 6→71, 7→72, 8→74, 9→76, 10→77.
+//
+// Each algorithm produces a specific traversal order from the deduped inputs.
+// ---------------------------------------------------------------------------
+
+/** Evaluate arp pattern and return degree-ordered MIDI notes per cycle. */
+function arpNotes(source: string): number[] {
+	return eval0(source).map((e) => pitched(e).note);
+}
+
+describe("'arp — arpeggiation modifier (truth table 25)", () => {
+	// Algorithm \up: sorted ascending
+	it("\\up (default): [0..10]'arp — degrees 0..10 ascending", () => {
+		const ns = arpNotes("note x [0..10]'arp");
+		expect(ns).toEqual([60, 62, 64, 65, 67, 69, 71, 72, 74, 76, 77]);
+	});
+
+	it("\\up explicit: [0..10]'arp(\\up) — same as bare 'arp", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\up)");
+		expect(ns).toEqual([60, 62, 64, 65, 67, 69, 71, 72, 74, 76, 77]);
+	});
+
+	// Algorithm \down: sorted descending
+	it("\\down: [0..10]'arp(\\down) — degrees 10..0 descending", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\down)");
+		expect(ns).toEqual([77, 76, 74, 72, 71, 69, 67, 65, 64, 62, 60]);
+	});
+
+	// Algorithm \inward: outer to inner (pincer from both ends)
+	// Input [0..10]: a0=0, a1=1, ..., a10=10 (N=11, odd — ends on middle a5=5)
+	// inward: a0, a10, a1, a9, a2, a8, a3, a7, a4, a6, a5
+	// → degrees: 0, 10, 1, 9, 2, 8, 3, 7, 4, 6, 5
+	it("\\inward: [0..10]'arp(\\inward) — outer to inner", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\inward)");
+		// degrees: 0, 10, 1, 9, 2, 8, 3, 7, 4, 6, 5 → MIDI:
+		expect(ns).toEqual([60, 77, 62, 76, 64, 74, 65, 72, 67, 71, 69]);
+	});
+
+	// Algorithm \outward: inner to outer (reverse of inward)
+	// inward on [0..10]: 0, 10, 1, 9, 2, 8, 3, 7, 4, 6, 5
+	// outward = reverse of inward: 5, 6, 4, 7, 3, 8, 2, 9, 1, 10, 0
+	it("\\outward: [0..10]'arp(\\outward) — inner to outer (reverse of inward)", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\outward)");
+		// degrees: 5, 6, 4, 7, 3, 8, 2, 9, 1, 10, 0 → MIDI:
+		expect(ns).toEqual([69, 71, 67, 72, 65, 74, 64, 76, 62, 77, 60]);
+	});
+
+	// Algorithm \updown: palindrome, no repeated endpoints
+	// [0..10] → 0 1 2 3 4 5 6 7 8 9 10 9 8 7 6 5 4 3 2 1 (20 values)
+	// ascending: 11 values (0..10), descending: 9 values (9..1, no repeated endpoints)
+	it("\\updown: [0..10]'arp(\\updown) — palindrome no repeated endpoints (20 values)", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\updown)");
+		expect(ns).toHaveLength(20);
+		// ascending half (indices 0..10)
+		expect(ns.slice(0, 11)).toEqual([60, 62, 64, 65, 67, 69, 71, 72, 74, 76, 77]);
+		// descending half (no repeated top or bottom): degrees 9,8,7,6,5,4,3,2,1
+		expect(ns.slice(11)).toEqual([76, 74, 72, 71, 69, 67, 65, 64, 62]);
+	});
+
+	// \converge is an alias for \inward
+	it("\\converge: [0..10]'arp(\\converge) — same as \\inward", () => {
+		expect(arpNotes("note x [0..10]'arp(\\converge)")).toEqual(
+			arpNotes("note x [0..10]'arp(\\inward)")
+		);
+	});
+
+	// \diverge is an alias for \outward
+	it("\\diverge: [0..10]'arp(\\diverge) — same as \\outward", () => {
+		expect(arpNotes("note x [0..10]'arp(\\diverge)")).toEqual(
+			arpNotes("note x [0..10]'arp(\\outward)")
+		);
+	});
+
+	// Inward/outward on even-length input
+	// [0..9] = 10 elements, N=10 (even)
+	// inward: a0, a9, a1, a8, a2, a7, a3, a6, a4, a5
+	// → degrees: 0, 9, 1, 8, 2, 7, 3, 6, 4, 5
+	it('\\inward on even-length [0..9]: pincer pairs ending at middle pair', () => {
+		const ns = arpNotes("note x [0..9]'arp(\\inward)");
+		// degrees: 0, 9, 1, 8, 2, 7, 3, 6, 4, 5
+		expect(ns).toEqual([60, 76, 62, 74, 64, 72, 65, 71, 67, 69]);
+	});
+
+	// outward on even-length [0..9]: reverse of inward
+	// inward [0..9]: 0, 9, 1, 8, 2, 7, 3, 6, 4, 5
+	// outward = reverse: 5, 4, 6, 3, 7, 2, 8, 1, 9, 0
+	it('\\outward on even-length [0..9]: reverse of \\inward', () => {
+		const ns = arpNotes("note x [0..9]'arp(\\outward)");
+		// degrees: 5, 4, 6, 3, 7, 2, 8, 1, 9, 0
+		expect(ns).toEqual([69, 67, 71, 65, 72, 64, 74, 62, 76, 60]);
+	});
+
+	// Length override: 'arp(\down 16) on [0..10] → 16 values cycling \down traversal
+	// \down traversal: [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0] (11 natural), cycling for 16:
+	// [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 10, 9, 8, 7, 6]
+	it("\\down 16: [0..10]'arp(\\down 16) — 16 values cycling", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\down 16)");
+		expect(ns).toHaveLength(16);
+		// First 11: the natural down traversal
+		expect(ns.slice(0, 11)).toEqual([77, 76, 74, 72, 71, 69, 67, 65, 64, 62, 60]);
+		// Wrapped: 10, 9, 8, 7, 6 (indices 0..4 of the traversal array)
+		expect(ns.slice(11)).toEqual([77, 76, 74, 72, 71]);
+	});
+
+	it("\\up 5: [0..10]'arp(\\up 5) — first 5 values of up traversal", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\up 5)");
+		expect(ns).toHaveLength(5);
+		expect(ns).toEqual([60, 62, 64, 65, 67]);
+	});
+
+	// Duplicate removal: preserves order of first occurrence
+	// [5 3 7 3 1] → deduped = [5 3 7 1]
+	// \up: sorted ascending = [1 3 5 7] → degrees: 1, 3, 5, 7
+	it("dedup: [5 3 7 3 1]'arp — removes duplicates by first occurrence", () => {
+		const ns = arpNotes("note x [5 3 7 3 1]'arp");
+		// \up: sorted numerically → degrees 1, 3, 5, 7 → MIDI 62, 65, 69, 72
+		expect(ns).toEqual([62, 65, 69, 72]);
+	});
+
+	// Single-element input: 'arp is a no-op (yields that single value)
+	it("single element: [4]'arp — no-op, yields degree 4", () => {
+		const ns = arpNotes("note x [4]'arp");
+		expect(ns).toEqual([67]); // degree 4 = G5 = MIDI 67
+	});
+
+	// Rests are filtered out before arpeggiation
+	// [0 _ 4 _ 8] → rests filtered → [0 4 8] → \up: [0 4 8]
+	it("rests filtered: [0 _ 4 _ 8]'arp — rests removed before arpeggiation", () => {
+		const ns = arpNotes("note x [0 _ 4 _ 8]'arp");
+		// degrees: 0, 4, 8 → MIDI: 60, 67, 74
+		expect(ns).toEqual([60, 67, 74]);
+	});
+
+	// All-rest input: yields a single rest event
+	it("all rests: [_ _ _]'arp — yields one rest event", () => {
+		const evs = eval0("note x [_ _ _]'arp");
+		expect(evs).toHaveLength(1);
+		expect(evs[0].contentType).toBe('rest');
+	});
+
+	// 'arp composes with 'stut at list level: 'arp runs first
+	it("'arp composes with 'stut: [0..3]'arp'stut(2) — 8 events (4 arped × 2)", () => {
+		const evs = eval0("note x [0..3]'arp'stut(2)");
+		expect(evs).toHaveLength(8);
+	});
+
+	// 'arp is list-level — attaching to a scalar inside a list is a semantic error
+	it("scalar generator with 'arp: [0rand7'arp] — semantic error", () => {
+		const i = createInstance("note x [0rand7'arp]");
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('arp');
+		}
+	});
+
+	// 'arp on same list as 'shuf is a semantic error
+	it("'arp'shuf combination — semantic error: cannot combine", () => {
+		const i = createInstance("note x [0..5]'arp'shuf");
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('arp');
+		}
+	});
+
+	// 'arp on same list as 'pick is a semantic error
+	it("'arp'pick combination — semantic error: cannot combine", () => {
+		const i = createInstance("note x [0..5]'arp'pick");
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('arp');
+		}
+	});
+
+	// Length override n=0 is a semantic error
+	it("'arp(\\up 0) — semantic error: n=0", () => {
+		const i = createInstance("note x [0..5]'arp(\\up 0)");
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('arp');
+		}
+	});
+
+	// Length override n negative is a semantic error
+	it("'arp(\\up -3) — semantic error: negative length", () => {
+		const i = createInstance("note x [0..5]'arp(\\up -3)");
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('arp');
+		}
+	});
+
+	// Unknown algorithm symbol is a semantic error
+	it("'arp(\\bogus) — semantic error: unknown algorithm", () => {
+		const i = createInstance("note x [0..5]'arp(\\bogus)");
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('arp');
+		}
+	});
+
+	// 'arp on a scalar top-level generator (not inside a list) — semantic error
+	it("'arp on scalar generator (not in a list) — semantic error", () => {
+		// The parser will see the modifierSuffix on the generator expression inside []
+		// When 'arp is placed on a scalar element inside a list, it's a semantic error
+		// (cannot attach to a non-list generator since 'arp is list-level only)
+		const i = createInstance("note x [0rand7'arp]");
+		expect(i.ok).toBe(false);
+		if (!i.ok) {
+			expect(i.error.toLowerCase()).toContain('arp');
+		}
+	});
+
+	// \updown length override
+	it("\\updown 5: [0..10]'arp(\\updown 5) — 5 values cycling updown traversal", () => {
+		const ns = arpNotes("note x [0..10]'arp(\\updown 5)");
+		expect(ns).toHaveLength(5);
+		// updown traversal for [0..10]: 0 1 2 3 4 5 6 7 8 9 10 9 8 7 6 5 4 3 2 1 (20 values)
+		// first 5: degrees 0, 1, 2, 3, 4 → MIDI 60, 62, 64, 65, 67
+		expect(ns).toEqual([60, 62, 64, 65, 67]);
+	});
+
+	// 'arp is evaluated at cycle boundary (repeatable across cycles)
+	it("'arp produces same result across multiple cycles", () => {
+		const i = inst("note x [0..4]'arp");
+		const r0 = i.evaluate({ cycleNumber: 0 });
+		const r1 = i.evaluate({ cycleNumber: 1 });
+		if (!r0.ok || !r1.ok) throw new Error('eval failed');
+		expect(r0.events.map((e) => pitched(e).note)).toEqual(r1.events.map((e) => pitched(e).note));
+	});
+});

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -927,6 +927,16 @@ function getSeriesLength(numGen: CstNode): number | null {
  * This replaces compileElement at the call sites inside compilePattern's element loop.
  */
 function compileElementWithSpread(elem: CstNode, inherited: EagerMode): CompiledElement[] | string {
+	// Semantic error: 'arp on a scalar generator inside a list.
+	// 'arp is a list-level modifier — it must be attached to the list itself, not to an element.
+	const genExprForArp = ((elem.children.generatorExpr as CstNode[]) ?? [])[0];
+	const elemModsForArp = genExprForArp
+		? ((genExprForArp.children.modifierSuffix as CstNode[]) ?? [])
+		: [];
+	if (hasModifier(elemModsForArp, 'arp')) {
+		return "'arp is a list-level modifier — attach it to the list [...], not to a scalar generator inside the list (e.g. use [0rand7]'arp, not [0rand7'arp])";
+	}
+
 	// Check for 'spread modifier.
 	// 'spread can appear in two places:
 	//   1. genExpr.modifierSuffix — for scalar generators (0rand7'spread)
@@ -1462,7 +1472,7 @@ function applySetStatement(setNode: CstNode, ctx: ScaleContext, cycle: number): 
 // ---------------------------------------------------------------------------
 
 /** Get the effective modifier name from a modifierSuffix node.
- * Handles both direct (Tick + Identifier) and atModifier sub-node cases.
+ * Handles both direct (Tick + Identifier) and atModifier/arpModifier sub-node cases.
  */
 function getModifierName(mod: CstNode): string | null {
 	// Direct Identifier on mod
@@ -1473,6 +1483,12 @@ function getModifierName(mod: CstNode): string | null {
 	if (atMod) {
 		const atId = ((atMod.children.Identifier as IToken[]) ?? [])[0];
 		if (atId) return atId.image;
+	}
+	// arpModifier sub-node
+	const arpMod = ((mod.children.arpModifier as CstNode[]) ?? [])[0];
+	if (arpMod) {
+		const arpId = ((arpMod.children.Identifier as IToken[]) ?? [])[0];
+		if (arpId) return arpId.image;
 	}
 	return null;
 }
@@ -1490,6 +1506,61 @@ function findModifier(mods: CstNode[], name: string): CstNode | null {
 /** Check if a modifier with a given name exists. */
 function hasModifier(mods: CstNode[], name: string): boolean {
 	return mods.some((mod) => getModifierName(mod) === name);
+}
+
+/**
+ * Extract the ArpConfig from a list of modifier nodes.
+ * Looks for an 'arp modifier (via arpModifier sub-node) and extracts:
+ *   - algorithm: the \symbol argument (stripped of '\'), default 'up'
+ *   - lengthOverride: integer argument, or null if absent
+ * Returns null if no 'arp modifier is present.
+ * Returns a string error message if the algorithm or length override is invalid.
+ */
+function extractArpConfig(mods: CstNode[]): ArpConfig | null | string {
+	const arpMod = mods.find((mod) => getModifierName(mod) === 'arp');
+	if (!arpMod) return null;
+
+	// Get the arpModifier sub-node
+	const arpModNode = ((arpMod.children.arpModifier as CstNode[]) ?? [])[0];
+	if (!arpModNode) {
+		// Bare 'arp — use default algorithm
+		return { algorithm: 'up', lengthOverride: null };
+	}
+
+	// Extract the Symbol token (algorithm)
+	const symTok = ((arpModNode.children.Symbol as IToken[]) ?? [])[0];
+	let algorithm: ArpAlgorithm = 'up';
+	if (symTok) {
+		const symName = symTok.image.slice(1); // strip leading '\'
+		const validAlgorithms: ArpAlgorithm[] = [
+			'up',
+			'down',
+			'inward',
+			'outward',
+			'updown',
+			'converge',
+			'diverge'
+		];
+		if (!validAlgorithms.includes(symName as ArpAlgorithm)) {
+			return `'arp: unknown algorithm '\\${symName}' — valid algorithms: \\up, \\down, \\inward, \\outward, \\updown, \\converge, \\diverge`;
+		}
+		algorithm = symName as ArpAlgorithm;
+	}
+
+	// Extract optional Integer (length override) — may have a leading Minus (semantic error)
+	const intTok = ((arpModNode.children.Integer as IToken[]) ?? [])[0];
+	let lengthOverride: number | null = null;
+	if (intTok) {
+		const minusTok = ((arpModNode.children.Minus as IToken[]) ?? [])[0];
+		const raw = parseInt(intTok.image, 10);
+		const n = minusTok ? -raw : raw;
+		if (n <= 0) {
+			return `'arp: length override must be a positive integer ≥ 1, got ${n}`;
+		}
+		lengthOverride = n;
+	}
+
+	return { algorithm, lengthOverride };
 }
 
 /** Extract a scalar number from a modifierSuffix's generatorExpr, with a default. */
@@ -1755,6 +1826,19 @@ function compileSequenceElementToPollFn(elem: CstNode): PollFn | null {
 /** List-level traversal modifier. */
 type TraversalMode = 'seq' | 'shuf' | 'pick';
 
+/** Arp algorithm — determines traversal order from deduped input values. */
+type ArpAlgorithm = 'up' | 'down' | 'inward' | 'outward' | 'updown' | 'converge' | 'diverge';
+
+/**
+ * Configuration for the 'arp list-level modifier.
+ * algorithm: traversal algorithm (default 'up')
+ * lengthOverride: if not null, cycle/wrap the natural traversal to produce exactly n values
+ */
+type ArpConfig = {
+	algorithm: ArpAlgorithm;
+	lengthOverride: number | null;
+};
+
 type ContentType = 'note' | 'mono' | 'sample' | 'slice' | 'cloud';
 
 type CompiledPattern = {
@@ -1763,6 +1847,7 @@ type CompiledPattern = {
 	elements: CompiledElement[];
 	listMode: EagerMode; // mode from list-level modifiers (inherited by elements)
 	traversal: TraversalMode;
+	arpConfig: ArpConfig | null; // null = no 'arp modifier
 	stutRunner: RunnerState | null; // null = no stutter
 	maybeRunner: RunnerState | null; // null = no maybe filter
 	legatoRunner: RunnerState | null; // null = default legato (0.8 for note)
@@ -1877,6 +1962,16 @@ function compilePattern(
 	let traversal: TraversalMode = 'seq';
 	if (hasModifier(listMods, 'shuf')) traversal = 'shuf';
 	else if (hasModifier(listMods, 'pick')) traversal = 'pick';
+
+	// 'arp modifier — arpeggiation traversal
+	const arpResult = extractArpConfig(listMods);
+	if (typeof arpResult === 'string') return arpResult; // semantic error
+	const arpConfig: ArpConfig | null = arpResult;
+
+	// Semantic error: 'arp cannot be combined with 'shuf or 'pick — they are all traversal strategies
+	if (arpConfig !== null && (traversal === 'shuf' || traversal === 'pick')) {
+		return `'arp cannot be combined with '${traversal} — choose one traversal strategy`;
+	}
 
 	// Warn when `?` weights are present on a list without 'pick — the weight
 	// is meaningless there and silently ignored. Matches spec truth table 4.
@@ -2068,6 +2163,7 @@ function compilePattern(
 		elements: compiled,
 		listMode,
 		traversal,
+		arpConfig,
 		stutRunner,
 		maybeRunner,
 		legatoRunner,
@@ -2194,6 +2290,137 @@ function evaluateFxEvent(compiledFx: CompiledFx, cycle: number, atOffset: number
 		wetDry: compiledFx.wetDry,
 		cycleOffset: atOffset // always present on FX events
 	};
+}
+
+// ---------------------------------------------------------------------------
+// 'arp algorithm implementations
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a deduped array of (value, element) pairs (sorted by index of first
+ * occurrence), compute the traversal order for the given algorithm.
+ *
+ * Returns an array of CompiledElement[] in traversal order.
+ * For algorithms with a natural length != N (e.g. \updown → 2*(N-1)), the
+ * output length may differ from the input length.
+ */
+function applyArpAlgorithm(
+	items: Array<{ value: number; element: CompiledElement }>,
+	algorithm: ArpAlgorithm
+): CompiledElement[] {
+	// Normalise \converge → \inward and \diverge → \outward
+	const algo: ArpAlgorithm =
+		algorithm === 'converge' ? 'inward' : algorithm === 'diverge' ? 'outward' : algorithm;
+
+	// Sort items by numeric value for sorted-order algorithms
+	const sorted = [...items].sort((a, b) => a.value - b.value);
+	const N = sorted.length;
+
+	if (algo === 'up') {
+		return sorted.map((x) => x.element);
+	}
+
+	if (algo === 'down') {
+		return sorted.map((x) => x.element).reverse();
+	}
+
+	if (algo === 'updown') {
+		// Palindrome: ascending then descending, no repeated endpoints
+		// For N elements: [0, 1, ..., N-1, N-2, ..., 1] → 2*(N-1) total
+		// For N=1: just [0] (single element — no-op)
+		if (N <= 1) return sorted.map((x) => x.element);
+		const asc = sorted.map((x) => x.element);
+		const desc = sorted
+			.slice(1, N - 1)
+			.reverse()
+			.map((x) => x.element);
+		return [...asc, ...desc];
+	}
+
+	if (algo === 'inward') {
+		// Pincer from both ends toward middle
+		// For N=11 (odd): a0, a10, a1, a9, ..., a5 (middle)
+		// For N=10 (even): a0, a9, a1, a8, ..., a4, a5 (middle pair)
+		const result: CompiledElement[] = [];
+		let lo = 0;
+		let hi = N - 1;
+		while (lo <= hi) {
+			if (lo === hi) {
+				// Odd: single middle element
+				result.push(sorted[lo].element);
+				lo++;
+			} else {
+				result.push(sorted[lo].element);
+				result.push(sorted[hi].element);
+				lo++;
+				hi--;
+			}
+		}
+		return result;
+	}
+
+	if (algo === 'outward') {
+		// Reverse of inward: start from middle, expand outward
+		const inward = applyArpAlgorithm(items, 'inward');
+		return [...inward].reverse();
+	}
+
+	return sorted.map((x) => x.element); // fallback
+}
+
+/**
+ * Apply 'arp transformation to a list of compiled elements.
+ *
+ * Steps:
+ *   1. Sample each element's runner to get numeric values.
+ *   2. Separate rests from pitched elements.
+ *   3. If all elements are rests → return [ZERO_WEIGHT_REST] (one rest event).
+ *   4. Deduplicate pitched elements by numeric equality (first occurrence wins).
+ *   5. Apply the arp algorithm to produce a traversal order.
+ *   6. If lengthOverride is set, cycle/wrap to produce exactly n elements.
+ *
+ * Returns an ordered CompiledElement[] ready for slot expansion.
+ */
+function applyArp(
+	elements: CompiledElement[],
+	arpConfig: ArpConfig,
+	cycle: number
+): CompiledElement[] {
+	// Step 1: Sample values from scalar elements; collect rests
+	type Item = { value: number; element: CompiledElement };
+	const pitched: Item[] = [];
+
+	for (const el of elements) {
+		if (el.kind === 'rest') continue; // skip rests
+		if (el.kind === 'scalar') {
+			const value = sampleRunner(el.runner, cycle);
+			// Deduplicate: only keep first occurrence of each value
+			const isDup = pitched.some((p) => p.value === value);
+			if (!isDup) {
+				pitched.push({ value, element: el });
+			}
+		} else {
+			// Subsequences, symbols, chords: include as-is (not arpeggiated)
+			// Treat them as non-numeric items; add without dedup
+			pitched.push({ value: NaN, element: el });
+		}
+	}
+
+	// Step 3: All rests → single rest event
+	if (pitched.length === 0) {
+		return [ZERO_WEIGHT_REST];
+	}
+
+	// Step 4: Apply arp algorithm to get traversal order
+	const traversal = applyArpAlgorithm(pitched, arpConfig.algorithm);
+
+	// Step 5: Apply length override (cycle/wrap)
+	if (arpConfig.lengthOverride !== null) {
+		const n = arpConfig.lengthOverride;
+		return Array.from({ length: n }, (_, i) => traversal[i % traversal.length]);
+	}
+
+	return traversal;
 }
 
 // ---------------------------------------------------------------------------
@@ -2436,7 +2663,10 @@ function evaluateCompiledPattern(
 	const maybeProb = maybeRunner ? sampleRunner(maybeRunner, cycle) : null;
 
 	// Determine the ordered sequence of elements (traversal strategy)
-	const orderedElements = orderedSubElements(elements, compiled.traversal, cycle);
+	// If 'arp is present it takes precedence and computes its own ordering.
+	const orderedElements = compiled.arpConfig
+		? applyArp(elements, compiled.arpConfig, cycle)
+		: orderedSubElements(elements, compiled.traversal, cycle);
 
 	// Apply 'stut: expand each element into stutCount copies
 	const expandedElements: CompiledElement[] = [];

--- a/src/lib/lang/hover.ts
+++ b/src/lib/lang/hover.ts
@@ -226,7 +226,7 @@ const TOKEN_TYPE_DOCS: Record<string, string> = {
 		'',
 		'Attaches a modifier to the immediately preceding token.',
 		'',
-		'Common modifiers: `lock`, `eager(n)`, `stut`, `maybe`, `legato`, `offset`, `at`, `n`, `shuf`, `pick`'
+		'Common modifiers: `lock`, `eager(n)`, `stut`, `maybe`, `legato`, `offset`, `at`, `n`, `shuf`, `pick`, `arp`'
 	].join('\n'),
 
 	At: [
@@ -316,6 +316,7 @@ const TOKEN_TYPE_DOCS: Record<string, string> = {
 		"[1 2 3]'shuf      // shuffle then traverse",
 		"[1 2 3]'pick      // uniform random element each time",
 		"[1 2?2 3]'pick    // weighted random (probs 0.25/0.5/0.25)",
+		"[0..10]'arp       // arpeggiate ascending (default \\up)",
 		'```'
 	].join('\n'),
 
@@ -445,6 +446,31 @@ const MODIFIER_DOCS: Record<string, string> = {
 		"[1 2 3 4]'pick        // uniform",
 		"[1 2?2 3]'pick        // probs 0.25 / 0.5 / 0.25",
 		"[1?0.5 2?1 3?2]'pick  // probs 0.14 / 0.29 / 0.57",
+		'```'
+	].join('\n'),
+
+	arp: [
+		"**`'arp`** — arpeggiate: collect cycle output, deduplicate, and traverse.",
+		'',
+		'Default algorithm is `\\up`. Rests are filtered before arpeggiation.',
+		'Duplicates are removed by numeric equality (first-occurrence order preserved).',
+		"Cannot be combined with `'shuf` or `'pick` — choose one traversal strategy.",
+		'',
+		'**Algorithms:**',
+		'- `\\up` — ascending (default)',
+		'- `\\down` — descending',
+		'- `\\inward` / `\\converge` — pincer from both ends toward the middle',
+		'- `\\outward` / `\\diverge` — starts at middle, expands outward',
+		'- `\\updown` — ascending then descending palindrome, no repeated endpoints (natural length = 2×(N−1))',
+		'',
+		"**Length override** `'arp(\\algorithm n)`: cycles the natural traversal to produce exactly n values.",
+		'',
+		'```flux',
+		"[0..10]'arp              // \\up — 0 1 2 3 4 5 6 7 8 9 10",
+		"[0..10]'arp(\\down)       // 10 9 8 7 6 5 4 3 2 1 0",
+		"[0..10]'arp(\\updown)     // 0..10..1 (20 values)",
+		"[0..10]'arp(\\down 16)    // 16 values, cycling \\down traversal",
+		"[0 5 2 7]'arp(\\inward)   // inward from sorted [0 2 5 7]",
 		'```'
 	].join('\n'),
 

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -947,3 +947,92 @@ describe('chord literals <>', () => {
 		expect(parseErrors.length + lexErrors.length).toBeGreaterThan(0);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 'arp modifier — arpeggiation from cycle output
+// ---------------------------------------------------------------------------
+
+describe("modifierSuffix — 'arp traversal modifier", () => {
+	it("parses bare 'arp on a list (default \\up algorithm)", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\up) — explicit algorithm", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\up)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\down) — down algorithm", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\down)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\inward) — inward algorithm", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\inward)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\outward) — outward algorithm", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\outward)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\updown) — updown algorithm", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\updown)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\converge) — converge alias", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\converge)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\diverge) — diverge alias", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\diverge)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\down 16) — algorithm with length override", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\down 16)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp(\\up 8) — up with length override", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0..10]'arp(\\up 8)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp on a range list [0,2..8]", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0,2..8]'arp");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses 'arp on an explicit list [0 5 2 7 3]", () => {
+		const { parseErrors, lexErrors } = parse("note lead [0 5 2 7 3]'arp(\\outward)");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("rejects 'arp on a scalar generator — parse error", () => {
+		// 'arp is a list-level modifier; attaching to a scalar is a semantic error
+		// caught at evaluation time. The parser should accept it structurally
+		// (since modifiers can attach to any generator expression), but the evaluator
+		// rejects it. This test just verifies no parse error for a typical wrong usage.
+		// (The semantic error is tested in the evaluator test file.)
+		const { parseErrors } = parse("note lead [0rand7'arp]");
+		// No parse error expected — semantic error is raised at eval time
+		expect(parseErrors).toHaveLength(0);
+	});
+});

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -964,15 +964,20 @@ class FluxParser extends CstParser {
 	});
 
 	modifierSuffix = this.RULE('modifierSuffix', () => {
-		// `'modName` or `'modName(generatorExpr)` or `'at(timeExpr)`
+		// `'modName` or `'modName(generatorExpr)` or `'at(timeExpr)` or `'arp(...)` (special args)
 		// 'at is the one modifier whose argument is a timeExpr (integer or
 		// integer/integer fraction) rather than a generatorExpr.  We gate on
 		// LA(2) being the identifier "at" before the tick is consumed so the
 		// parser can branch correctly.
+		// 'arp has its own argument syntax: `(\symbol)` or `(\symbol integer)`.
 		this.OR([
 			{
 				GATE: () => this.LA(2).image === 'at',
 				ALT: () => this.SUBRULE(this.atModifier)
+			},
+			{
+				GATE: () => this.LA(2).image === 'arp',
+				ALT: () => this.SUBRULE(this.arpModifier)
 			},
 			{
 				ALT: () => {
@@ -986,6 +991,35 @@ class FluxParser extends CstParser {
 				}
 			}
 		]);
+	});
+
+	arpModifier = this.RULE('arpModifier', () => {
+		// 'arp                        — bare (default \up algorithm)
+		// 'arp(\symbol)               — explicit algorithm
+		// 'arp(\symbol integer)        — algorithm with length override (positive integer)
+		// 'arp(\symbol -integer)       — negative length: parsed here, semantic error in evaluator
+		//
+		// CST children:
+		//   Tick[0]     — the `'` token
+		//   Identifier[0] — always "arp"
+		//   LParen[0]   — present if args follow
+		//   Symbol[0]   — algorithm symbol (e.g. \up, \down)
+		//   Minus[0]    — present if length is negative (semantic error — caught in evaluator)
+		//   Integer[0]  — optional length override
+		//   RParen[0]   — closing paren
+		this.CONSUME(Tick);
+		this.CONSUME(Identifier); // always "arp"
+		this.OPTION(() => {
+			this.CONSUME(LParen);
+			this.CONSUME(Symbol); // algorithm symbol: \up, \down, etc.
+			this.OPTION2(() => {
+				this.OPTION3(() => {
+					this.CONSUME(Minus); // optional leading minus (caught as semantic error in evaluator)
+				});
+				this.CONSUME(Integer); // optional length override
+			});
+			this.CONSUME(RParen);
+		});
 	});
 
 	atModifier = this.RULE('atModifier', () => {


### PR DESCRIPTION
## Summary

- Adds `'arp` as a list-level traversal modifier for arpeggiation of cycle output values
- Seven algorithms: `\up` (default), `\down`, `\inward`, `\outward`, `\updown`, `\converge` (alias for `\inward`), `\diverge` (alias for `\outward`)
- Optional length override `'arp(\algorithm n)` cycles the natural traversal to exactly n values
- Duplicate removal by numeric equality (first-occurrence order), rests filtered before arpeggiation
- Full spec/truth-table/completions/hover documentation in sync

## Design decisions

- `\updown` natural length = `2*(N-1)` (palindrome, no repeated endpoints) — truth table is authoritative per pre-resolved design notes
- `\converge`/`\diverge` are thin aliases (single code path via `\inward`/`\outward`)
- Even-length `\inward`: pincer pairs ending at the two middle elements; `\outward` reverses
- Semantic errors: `'arp` on a scalar element inside a list, `'arp`+`'shuf`/`'pick` combination, unknown algorithm, length override ≤ 0

## Implementation

**Parser** — added `arpModifier` rule (special argument syntax `(\symbol)` or `(\symbol integer)`) gated by `LA(2).image === 'arp'` in `modifierSuffix`, mirroring the existing `atModifier` pattern.

**Evaluator** — `ArpAlgorithm` and `ArpConfig` types; `extractArpConfig()` extracts config from CST; `applyArpAlgorithm()` implements pure traversal logic; `applyArp()` does the full pipeline (sample runners → filter rests → dedupe → algorithm → length override). Integrated into `evaluateCompiledPattern` alongside existing traversal strategies.

**Files changed:** `parser.ts`, `evaluator.ts`, `completions.ts`, `hover.ts`, `docs/DSL-spec.md`, `docs/DSL-truthtables.md`, `parser.test.ts`, `evaluator.test.ts`

## Test plan

- [x] Parser accepts bare `'arp`, `'arp(\symbol)`, `'arp(\symbol n)` forms for all 7 algorithms
- [x] All 7 algorithms produce correct output against canonical `[0..10]` input
- [x] Even-length `\inward`/`\outward` correct for `[0..9]`
- [x] Length override cycles the traversal correctly
- [x] Duplicate removal and rest filtering verified
- [x] Single-element no-op
- [x] All-rest input yields one rest event
- [x] `'arp` + `'stut` composition
- [x] Semantic errors: scalar-element arp, arp+shuf, arp+pick, unknown algorithm, n≤0
- [x] Result stable across cycles

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)