### PR TITLE
feat(DSL): 'rev, 'mirror, 'bounce — sequence shape modifiers

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -351,7 +351,7 @@ Three modifiers that reshape the event array for a cycle _after_ traversal and s
 **Semantics:**
 
 - **`'rev`** — reverses the event array. `[a b c d]'rev` → `[d c b a]`.
-- **`'mirror`** — appends the full reverse of the array: `[a b c]'mirror` → `[a b c b a]`. Both endpoints appear twice — natural length = `2N − 1`.
+- **`'mirror`** — appends the reverse of the array without its first element: `[a b c]'mirror` → `[a b c b a]`. Both endpoints appear twice — natural length = `2N − 1`.
 - **`'bounce`** — appends the reverse with both endpoints removed: `[a b c]'bounce` → `[a b c b]`. No endpoint repeats — natural length = `2(N − 1)`.
 
 **Applied post-traversal:** shape modifiers operate on the evaluated event array after traversal (`'shuf`, `'pick`, `'arp`). `[1~4]'rev` reverses this cycle's random draws, not the generator. The modifier is re-applied each cycle.

--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -336,6 +336,34 @@ note lead [A 0step1x4'spread]
 
 See truth table [24 (`'spread`)](DSL-truthtables.md#24-spread-truth-table) for the complete interaction truth table.
 
+### Sequence shape modifiers (`'rev`, `'mirror`, `'bounce`)
+
+> _See truth table [26 (Sequence shape modifiers)](DSL-truthtables.md#26-sequence-shape-modifiers-truth-table)._
+
+Three modifiers that reshape the event array for a cycle _after_ traversal and sampling — not on the generator structure. They are **list-level modifiers** attached to `[...]`.
+
+```flux
+[1 2 3 4]'rev      // reverses: plays as [4 3 2 1]
+[1 2 3]'mirror     // palindrome (repeated endpoints): [1 2 3 2 1]
+[1 2 3]'bounce     // palindrome (no repeated endpoints): [1 2 3 2]
+```
+
+**Semantics:**
+
+- **`'rev`** — reverses the event array. `[a b c d]'rev` → `[d c b a]`.
+- **`'mirror`** — appends the full reverse of the array: `[a b c]'mirror` → `[a b c b a]`. Both endpoints appear twice — natural length = `2N − 1`.
+- **`'bounce`** — appends the reverse with both endpoints removed: `[a b c]'bounce` → `[a b c b]`. No endpoint repeats — natural length = `2(N − 1)`.
+
+**Applied post-traversal:** shape modifiers operate on the evaluated event array after traversal (`'shuf`, `'pick`, `'arp`). `[1~4]'rev` reverses this cycle's random draws, not the generator. The modifier is re-applied each cycle.
+
+**Cycle duration is fixed.** `'mirror` and `'bounce` produce more events per cycle; each event gets a proportionally shorter time slot, consistent with sublist behaviour.
+
+**Single-element is a no-op.** Applying any shape modifier to a one-element sequence returns `[a]` unchanged, with no error.
+
+**Composition with `'stut`:** shape modifiers apply before `'stut`. `[1 2 3]'mirror'stut(2)` → mirror first (5 elements), then stutter each (10 events).
+
+**Grammar:** bare modifier — no arguments. `'rev`, `'mirror`, and `'bounce` take no arguments.
+
 ---
 
 ## Content types

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -656,3 +656,42 @@ Default pitch context: C major / C5. Degree → MIDI: 0→60, 1→62, 2→64, 3�
 | `note x [0..5]'arp(\bogus)` | Semantic error | Unknown algorithm symbol                                                          |
 | `note x [0..5]'arp(\up 0)`  | Semantic error | Length override must be a positive integer ≥ 1                                    |
 | `note x [0..5]'arp(\up -3)` | Semantic error | Negative length override is not meaningful                                        |
+
+---
+
+# 26. **Sequence Shape Modifiers Truth Table**
+
+`'rev`, `'mirror`, `'bounce` — transform the event array post-traversal. Applied after `'shuf`/`'pick`/`'arp` and before `'stut`.
+
+## `'rev` — reverse
+
+| Code Snippet           | Interpretation               | Evaluation                       | Result                                    |
+| ---------------------- | ---------------------------- | -------------------------------- | ----------------------------------------- |
+| `note x [1 2 3 4]'rev` | Reverse the 4-element array. | Array reversed: `[4 3 2 1]`.     | 4 events; beatOffsets 0, 0.25, 0.5, 0.75. |
+| `note x [1 2 3]'rev`   | Reverse 3-element array.     | Array reversed: `[3 2 1]`.       | 3 events at degrees 3, 2, 1.              |
+| `note x [5]'rev`       | Single-element — no-op.      | Reverse of length-1 is itself.   | 1 event at degree 5.                      |
+| `note x [1~4]'rev`     | Random draw then reverse.    | Draws evaluated; array reversed. | This cycle's random values, reversed.     |
+
+## `'mirror` — palindrome with repeated endpoints
+
+| Code Snippet            | Interpretation                            | Evaluation                                                          | Result                             |
+| ----------------------- | ----------------------------------------- | ------------------------------------------------------------------- | ---------------------------------- |
+| `note x [1 2 3]'mirror` | Append reverse without its first element. | `[1 2 3]` + `[2 1]` = `[1 2 3 2 1]`. Natural length = `2N − 1` = 5. | 5 events at degrees 1, 2, 3, 2, 1. |
+| `note x [1 2]'mirror`   | 2-element palindrome.                     | `[1 2]` + `[1]` = `[1 2 1]`. Natural length = `2N − 1` = 3.         | 3 events at degrees 1, 2, 1.       |
+| `note x [5]'mirror`     | Single-element — no-op.                   | Reverse without first element is empty; result is `[5]`.            | 1 event at degree 5.               |
+
+## `'bounce` — palindrome without repeated endpoints
+
+| Code Snippet            | Interpretation                              | Evaluation                                                                                               | Result                          |
+| ----------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `note x [1 2 3]'bounce` | Append reverse with both endpoints removed. | `[1 2 3]` + rev-without-first-and-last = `[1 2 3]` + `[2]` = `[1 2 3 2]`. Natural length = `2(N−1)` = 4. | 4 events at degrees 1, 2, 3, 2. |
+| `note x [1 2]'bounce`   | 2-element bounce.                           | Reverse without both endpoints is empty; result = `[1 2]`. Natural length = 2.                           | 2 events at degrees 1, 2.       |
+| `note x [5]'bounce`     | Single-element — no-op.                     | Nothing to append; result is `[5]`.                                                                      | 1 event at degree 5.            |
+
+## Interaction with `'stut`
+
+| Code Snippet                    | Interpretation                           | Evaluation                           | Result     |
+| ------------------------------- | ---------------------------------------- | ------------------------------------ | ---------- |
+| `note x [1 2 3]'mirror'stut(2)` | mirror first (5 elements), then stutter. | `[1 2 3 2 1]` → stut(2) → 10 events. | 10 events. |
+| `note x [1 2 3]'bounce'stut(2)` | bounce first (4 elements), then stutter. | `[1 2 3 2]` → stut(2) → 8 events.    | 8 events.  |
+| `note x [1 2 3 4]'rev'stut(2)`  | rev first (4 elements), then stutter.    | `[4 3 2 1]` → stut(2) → 8 events.    | 8 events.  |

--- a/src/lib/lang/completions.test.ts
+++ b/src/lib/lang/completions.test.ts
@@ -318,4 +318,29 @@ describe('CompletionItem shape', () => {
 			expect(s.insertText).toContain('${');
 		}
 	});
+
+	// Shape modifier completions
+	it("returns 'rev completion for trigger '", () => {
+		const items = getCompletions([], 0, "'");
+		const rev = items.find((i) => i.label === 'rev');
+		expect(rev).toBeDefined();
+		expect(rev?.insertText).toBe('rev');
+		expect(rev?.kind).toBe('keyword');
+	});
+
+	it("returns 'mirror completion for trigger '", () => {
+		const items = getCompletions([], 0, "'");
+		const mirror = items.find((i) => i.label === 'mirror');
+		expect(mirror).toBeDefined();
+		expect(mirror?.insertText).toBe('mirror');
+		expect(mirror?.kind).toBe('keyword');
+	});
+
+	it("returns 'bounce completion for trigger '", () => {
+		const items = getCompletions([], 0, "'");
+		const bounce = items.find((i) => i.label === 'bounce');
+		expect(bounce).toBeDefined();
+		expect(bounce?.insertText).toBe('bounce');
+		expect(bounce?.kind).toBe('keyword');
+	});
 });

--- a/src/lib/lang/completions.ts
+++ b/src/lib/lang/completions.ts
@@ -175,6 +175,30 @@ const MODIFIER_COMPLETIONS: CompletionItem[] = [
 		detail: "'tail(s) — release FX after s seconds of silence",
 		documentation: 'Applies to anonymous insert FX (fx(...)).',
 		kind: 'snippet'
+	},
+	{
+		label: 'rev',
+		insertText: 'rev',
+		detail: "'rev — reverse event array each cycle",
+		documentation:
+			"Reverses the evaluated event array after traversal. [1 2 3 4]'rev → [4 3 2 1]. Single-element is a no-op.",
+		kind: 'keyword'
+	},
+	{
+		label: 'mirror',
+		insertText: 'mirror',
+		detail: "'mirror — palindrome with repeated endpoints",
+		documentation:
+			"Appends the reverse to the event array (both endpoints repeated). [1 2 3]'mirror → [1 2 3 2 1]. Natural length = 2N−1. Single-element is a no-op.",
+		kind: 'keyword'
+	},
+	{
+		label: 'bounce',
+		insertText: 'bounce',
+		detail: "'bounce — palindrome without repeated endpoints",
+		documentation:
+			"Appends the reverse with both endpoints removed (ping-pong). [1 2 3]'bounce → [1 2 3 2]. Natural length = 2(N−1). Single-element is a no-op.",
+		kind: 'keyword'
 	}
 ];
 

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -3313,3 +3313,145 @@ describe("'arp — arpeggiation modifier (truth table 25)", () => {
 		expect(ns).toEqual([62, 72, 65, 69]);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 14. Sequence shape modifiers — 'rev, 'mirror, 'bounce (truth table 26)
+//
+// C major degree → MIDI: 0→60, 1→62, 2→64, 3→65, 4→67
+// ---------------------------------------------------------------------------
+
+describe("'rev — reverse event array (truth table 26)", () => {
+	it("[1 2 3 4]'rev reverses to [4 3 2 1]", () => {
+		// degrees 1,2,3,4 → MIDI 62,64,65,67; reversed → 67,65,64,62
+		expect(notes("note x [1 2 3 4]'rev")).toEqual([67, 65, 64, 62]);
+	});
+
+	it("[1 2 3]'rev reverses to [3 2 1]", () => {
+		// degrees 1,2,3 → MIDI 62,64,65; reversed → 65,64,62
+		expect(notes("note x [1 2 3]'rev")).toEqual([65, 64, 62]);
+	});
+
+	it("[5]'rev — single element is a no-op", () => {
+		// degree 5 → MIDI 69
+		expect(notes("note x [5]'rev")).toEqual([69]);
+	});
+
+	it("[1 2 3 4]'rev produces 4 events with even beatOffsets", () => {
+		const evs = eval0("note x [1 2 3 4]'rev");
+		expect(evs).toHaveLength(4);
+		expect(evs[0].beatOffset).toBeCloseTo(0);
+		expect(evs[1].beatOffset).toBeCloseTo(0.25);
+		expect(evs[2].beatOffset).toBeCloseTo(0.5);
+		expect(evs[3].beatOffset).toBeCloseTo(0.75);
+	});
+
+	it("[1 2 3 4]'rev does not change event count or slot durations", () => {
+		const ds = durations("note x [1 2 3 4]'rev");
+		expect(ds).toHaveLength(4);
+		for (const d of ds) expect(d).toBeCloseTo(0.25 * 0.8); // default legato 0.8
+	});
+
+	it("'rev applies after 'shuf — reverses this cycle's shuffled draws", () => {
+		// Can only verify that all 3 notes are present in both shuffled and reversed positions
+		const i = inst("note x [0 2 4]'shuf'rev");
+		for (let c = 0; c < 5; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			expect(r.events).toHaveLength(3);
+			const ns = new Set(r.events.map((e) => pitched(e).note));
+			expect(ns.has(60)).toBe(true);
+			expect(ns.has(64)).toBe(true);
+			expect(ns.has(67)).toBe(true);
+		}
+	});
+});
+
+describe("'mirror — palindrome with repeated endpoints (truth table 26)", () => {
+	it("[1 2 3]'mirror produces [1 2 3 2 1]", () => {
+		// degrees 1,2,3 → MIDI 62,64,65; mirror → 62,64,65,64,62
+		expect(notes("note x [1 2 3]'mirror")).toEqual([62, 64, 65, 64, 62]);
+	});
+
+	it("[1 2]'mirror produces [1 2 1]", () => {
+		// degrees 1,2 → MIDI 62,64; mirror → 62,64,62
+		expect(notes("note x [1 2]'mirror")).toEqual([62, 64, 62]);
+	});
+
+	it("[5]'mirror — single element is a no-op", () => {
+		expect(notes("note x [5]'mirror")).toEqual([69]);
+	});
+
+	it("[1 2 3]'mirror produces 5 events (2N−1 = 5)", () => {
+		expect(eval0("note x [1 2 3]'mirror")).toHaveLength(5);
+	});
+
+	it("[1 2 3]'mirror — each event gets 1/5 cycle slot", () => {
+		const evs = eval0("note x [1 2 3]'mirror");
+		expect(evs).toHaveLength(5);
+		for (const ev of evs) {
+			expect(ev.duration).toBeCloseTo((1 / 5) * 0.8);
+		}
+	});
+
+	it("[1 2 3]'mirror — beat offsets are evenly spaced at 1/5", () => {
+		const evs = eval0("note x [1 2 3]'mirror");
+		for (let i = 0; i < 5; i++) {
+			expect(evs[i].beatOffset).toBeCloseTo(i / 5);
+		}
+	});
+});
+
+describe("'bounce — palindrome without repeated endpoints (truth table 26)", () => {
+	it("[1 2 3]'bounce produces [1 2 3 2]", () => {
+		// degrees 1,2,3 → MIDI 62,64,65; bounce → 62,64,65,64
+		expect(notes("note x [1 2 3]'bounce")).toEqual([62, 64, 65, 64]);
+	});
+
+	it("[1 2]'bounce produces [1 2] — reverse without endpoints is empty", () => {
+		// degrees 1,2 → MIDI 62,64; bounce: reverse=[2,1], drop first+last=[]; append nothing → [1,2]
+		expect(notes("note x [1 2]'bounce")).toEqual([62, 64]);
+	});
+
+	it("[5]'bounce — single element is a no-op", () => {
+		expect(notes("note x [5]'bounce")).toEqual([69]);
+	});
+
+	it("[1 2 3]'bounce produces 4 events (2(N−1) = 4)", () => {
+		expect(eval0("note x [1 2 3]'bounce")).toHaveLength(4);
+	});
+
+	it("[1 2 3]'bounce — each event gets 1/4 cycle slot", () => {
+		const evs = eval0("note x [1 2 3]'bounce");
+		expect(evs).toHaveLength(4);
+		for (const ev of evs) {
+			expect(ev.duration).toBeCloseTo((1 / 4) * 0.8);
+		}
+	});
+
+	it("[1 2 3]'bounce — beat offsets are evenly spaced at 1/4", () => {
+		const evs = eval0("note x [1 2 3]'bounce");
+		for (let i = 0; i < 4; i++) {
+			expect(evs[i].beatOffset).toBeCloseTo(i / 4);
+		}
+	});
+});
+
+describe("shape modifiers × 'stut composition (truth table 26)", () => {
+	it("[1 2 3]'mirror'stut(2) — 10 events (5 mirrored × stut 2)", () => {
+		expect(eval0("note x [1 2 3]'mirror'stut(2)")).toHaveLength(10);
+	});
+
+	it("[1 2 3]'bounce'stut(2) — 8 events (4 bounced × stut 2)", () => {
+		expect(eval0("note x [1 2 3]'bounce'stut(2)")).toHaveLength(8);
+	});
+
+	it("[1 2 3 4]'rev'stut(2) — 8 events (4 reversed × stut 2)", () => {
+		expect(eval0("note x [1 2 3 4]'rev'stut(2)")).toHaveLength(8);
+	});
+
+	it("[1 2 3 4]'rev'stut(2) — degrees are reversed before stuttering", () => {
+		// [1 2 3 4]'rev = [4 3 2 1]; stut(2) → [4 4 3 3 2 2 1 1]
+		// degrees 4,3,2,1 → MIDI 67,65,64,62; stut doubles: [67,67,65,65,64,64,62,62]
+		expect(notes("note x [1 2 3 4]'rev'stut(2)")).toEqual([67, 67, 65, 65, 64, 64, 62, 62]);
+	});
+});

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -1826,6 +1826,9 @@ function compileSequenceElementToPollFn(elem: CstNode): PollFn | null {
 /** List-level traversal modifier. */
 type TraversalMode = 'seq' | 'shuf' | 'pick';
 
+/** Sequence shape modifier — applied post-traversal, pre-stut. */
+type ShapeMode = 'none' | 'rev' | 'mirror' | 'bounce';
+
 /** Arp algorithm — determines traversal order from deduped input values. */
 type ArpAlgorithm = 'up' | 'down' | 'inward' | 'outward' | 'updown' | 'converge' | 'diverge';
 
@@ -1847,6 +1850,7 @@ type CompiledPattern = {
 	elements: CompiledElement[];
 	listMode: EagerMode; // mode from list-level modifiers (inherited by elements)
 	traversal: TraversalMode;
+	shapeMode: ShapeMode; // post-traversal shape modifier ('rev, 'mirror, 'bounce); 'none = no transform
 	arpConfig: ArpConfig | null; // null = no 'arp modifier
 	stutRunner: RunnerState | null; // null = no stutter
 	maybeRunner: RunnerState | null; // null = no maybe filter
@@ -2087,6 +2091,12 @@ function compilePattern(
 		offsetRunner = extractModifierScalar(allMods, 'offset', 0, 0);
 	}
 
+	// Sequence shape modifiers: 'rev, 'mirror, 'bounce (post-traversal, pre-stut)
+	let shapeMode: ShapeMode = 'none';
+	if (hasModifier(allMods, 'rev')) shapeMode = 'rev';
+	else if (hasModifier(allMods, 'mirror')) shapeMode = 'mirror';
+	else if (hasModifier(allMods, 'bounce')) shapeMode = 'bounce';
+
 	// Content type: detected from content type keyword token on the patternStatement node
 	const contentType: ContentType = ((patternNode.children.Mono as IToken[]) ?? [])[0]
 		? 'mono'
@@ -2163,6 +2173,7 @@ function compilePattern(
 		elements: compiled,
 		listMode,
 		traversal,
+		shapeMode,
 		arpConfig,
 		stutRunner,
 		maybeRunner,
@@ -2433,6 +2444,34 @@ const ZERO_WEIGHT_REST: CompiledElement = {
 	weight: makeRunner(() => 1, { kind: 'lock' })
 };
 
+/**
+ * Apply a sequence shape modifier to an ordered element array.
+ *
+ * - 'rev: reverse the array
+ * - 'mirror: append reverse with first element of reverse removed (palindrome with repeated endpoints)
+ *   [a b c] → [a b c b a]  (natural length = 2N−1)
+ * - 'bounce: append reverse with both endpoints removed (ping-pong, no repeated endpoints)
+ *   [a b c] → [a b c b]   (natural length = 2(N−1))
+ * - 'none: no transform (pass-through)
+ *
+ * Single-element input is always a no-op (returns the array unchanged) for all modes.
+ */
+function applyShapeMode(elements: CompiledElement[], mode: ShapeMode): CompiledElement[] {
+	if (mode === 'none' || elements.length <= 1) return elements;
+	const rev = [...elements].reverse();
+	if (mode === 'rev') {
+		return rev;
+	} else if (mode === 'mirror') {
+		// [a b c] + rev.slice(1) = [a b c] + [b a] = [a b c b a]
+		return [...elements, ...rev.slice(1)];
+	} else {
+		// mode === 'bounce'
+		// [a b c] + rev.slice(1, -1) = [a b c] + [b] = [a b c b]
+		// For 2 elements: rev.slice(1, -1) = [] → no append → [a b]
+		return [...elements, ...rev.slice(1, -1)];
+	}
+}
+
 /** Apply traversal strategy to an element array, returning the ordered sequence. */
 function orderedSubElements(
 	elements: CompiledElement[],
@@ -2664,9 +2703,12 @@ function evaluateCompiledPattern(
 
 	// Determine the ordered sequence of elements (traversal strategy)
 	// If 'arp is present it takes precedence and computes its own ordering.
-	const orderedElements = compiled.arpConfig
+	const traversedElements = compiled.arpConfig
 		? applyArp(elements, compiled.arpConfig, cycle)
 		: orderedSubElements(elements, compiled.traversal, cycle);
+
+	// Apply sequence shape modifier post-traversal: 'rev, 'mirror, 'bounce
+	const orderedElements = applyShapeMode(traversedElements, compiled.shapeMode);
 
 	// Apply 'stut: expand each element into stutCount copies
 	const expandedElements: CompiledElement[] = [];

--- a/src/lib/lang/hover.test.ts
+++ b/src/lib/lang/hover.test.ts
@@ -302,3 +302,47 @@ describe('HoverResult shape', () => {
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 9. Shape modifier hover docs ('rev, 'mirror, 'bounce)
+// ---------------------------------------------------------------------------
+
+describe("getHover — 'rev, 'mirror, 'bounce modifier docs", () => {
+	function modifierToken(name: string): IToken {
+		// Tokenize `[0]'rev` — the modifier identifier is the last token
+		const toks = tokens(`[0]'${name}`);
+		// Last token is the identifier for the modifier name
+		return toks[toks.length - 1];
+	}
+
+	it("'rev — hover shows reverse documentation", () => {
+		const tok = modifierToken('rev');
+		const result = getHover(tok, 'Tick');
+		expect(result).not.toBeNull();
+		expect(result!.contents).toContain('rev');
+		expect(result!.contents).toContain('reverse');
+	});
+
+	it("'mirror — hover shows palindrome documentation", () => {
+		const tok = modifierToken('mirror');
+		const result = getHover(tok, 'Tick');
+		expect(result).not.toBeNull();
+		expect(result!.contents).toContain('mirror');
+		expect(result!.contents).toContain('palindrome');
+	});
+
+	it("'bounce — hover shows ping-pong documentation", () => {
+		const tok = modifierToken('bounce');
+		const result = getHover(tok, 'Tick');
+		expect(result).not.toBeNull();
+		expect(result!.contents).toContain('bounce');
+	});
+
+	it("'rev image-based fallback lookup (no Tick context)", () => {
+		// Without prevTokenName='Tick', should still find rev via image-based fallback
+		const tok = modifierToken('rev');
+		const result = getHover(tok);
+		expect(result).not.toBeNull();
+		expect(result!.contents).toContain('rev');
+	});
+});

--- a/src/lib/lang/hover.ts
+++ b/src/lib/lang/hover.ts
@@ -480,6 +480,39 @@ const MODIFIER_DOCS: Record<string, string> = {
 		'```flux',
 		'note [0 2 4 7] | fx("lpf")\'cutoff(1200)\'tail(4)',
 		'```'
+	].join('\n'),
+
+	rev: [
+		"**`'rev`** — reverse the event array each cycle.",
+		'',
+		"Operates on the evaluated event array _after_ traversal (`'shuf`, `'pick`, `'arp`). Single-element sequences are unchanged.",
+		'',
+		'```flux',
+		"[1 2 3 4]'rev     // plays as [4 3 2 1]",
+		"[1~4]'rev         // this cycle's random draws, reversed",
+		'```'
+	].join('\n'),
+
+	mirror: [
+		"**`'mirror`** — palindrome with repeated endpoints.",
+		'',
+		'Appends the reverse of the event array (excluding only the first element of the reverse, so both original endpoints appear twice). Natural length = 2N − 1. Single-element is a no-op.',
+		'',
+		'```flux',
+		"[1 2 3]'mirror    // [1 2 3 2 1] — 5 events",
+		"[0..3]'mirror     // [0 1 2 3 2 1 0] — 7 events",
+		'```'
+	].join('\n'),
+
+	bounce: [
+		"**`'bounce`** — ping-pong palindrome without repeated endpoints.",
+		'',
+		'Appends the reverse with both endpoints removed. Natural length = 2(N − 1). Single-element is a no-op.',
+		'',
+		'```flux',
+		"[1 2 3]'bounce    // [1 2 3 2] — 4 events",
+		"[0..3]'bounce     // [0 1 2 3 2 1] — 6 events",
+		'```'
 	].join('\n')
 };
 


### PR DESCRIPTION
## Summary

Implements issue #35 — three post-traversal sequence shape modifiers:

- **`'rev`** — reverses the event array: `[1 2 3 4]'rev` → `[4 3 2 1]`
- **`'mirror`** — palindrome with repeated endpoints: `[1 2 3]'mirror` → `[1 2 3 2 1]` (2N−1 events)
- **`'bounce`** — ping-pong without repeated endpoints: `[1 2 3]'bounce` → `[1 2 3 2]` (2(N−1) events)

All three apply **after** traversal (`'shuf`/`'pick`/`'arp`) and **before** `'stut`. Cycle duration is fixed — more events means proportionally shorter time slots. Single-element sequences are a no-op.

## Implementation

- **No parser changes** — existing `modifierSuffix` grammar already accepts bare `'identifier` modifiers
- `evaluator.ts` — added `ShapeMode` type, `shapeMode` field on `CompiledPattern`, `applyShapeMode()` function, and wired it into the evaluation pipeline between traversal and stutter
- `completions.ts` — three new entries in `MODIFIER_COMPLETIONS`
- `hover.ts` — three new entries in `MODIFIER_DOCS`
- `docs/DSL-spec.md` — new "Sequence shape modifiers" subsection
- `docs/DSL-truthtables.md` — new truth table §26

## Tests

29 new tests covering:
- Basic reversal, mirror, bounce on 2-, 3-, and 4-element lists
- Single-element no-op for all three modifiers
- Beat offsets and slot durations for expanded sequences
- Composition with `'stut` (shape first, then stutter)
- Interaction with `'shuf` (reverses shuffled draws)
- Completions and hover docs for all three modifiers

Closes #35