### PR TITLE
feat(DSL): @buf generator expression — per-cycle buffer selection

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -459,11 +459,14 @@ mono bass [0 1 2 3]'stut  // each pitch change sent twice
 
 **Channel-count-based SynthDef variant selection:** At event dispatch time, the channel count of the active buffer is looked up from the buffer registry. The SynthDef name is resolved to `samplePlayer_mono` or `samplePlayer_stereo` (and similarly for `slicePlayer`). If no variant exists for the detected channel count, the event is skipped with a logged error. `grainCloud` SynthDefs only exist as `_mono` variants — if a stereo buffer is selected, a warning is logged and the mono variant is used.
 
-**`@buf` decorator:** `@buf(\name)` specifies which buffer a `slice` or `cloud` pattern operates on. Accepts generator expressions for per-cycle buffer selection:
+**`@buf` decorator:** `@buf(\name)` specifies which buffer a `slice` or `cloud` pattern operates on. Accepts a static `\symbol` or any sequence generator for per-cycle buffer selection — the same traversal modifiers (`'pick`, `'shuf`, sequential, `'lock`, `'eager`) apply as on any `[...]` list. The generator is polled once per cycle; all events within the cycle share the same buffer name.
 
 ```flux
-@buf(\myloop) slice drums [0 2 4 8]'numSlices(16)
-@buf([\loopA \loopB]'pick) slice drums [0 4 8 12]
+@buf(\myloop) slice drums [0 2 4 8]'numSlices(16)           // static
+@buf([\loopA \loopB]'pick) slice drums [0 4 8 12]           // random per cycle
+@buf([\a \b \c]'shuf) slice drums [0 4 8 12]                // shuffle deck
+@buf([\loopA \loopB]) slice drums [0 4 8 12]                // sequential cycling
+@buf([\loopA \loopB]'lock) slice drums [0 4 8 12]           // frozen after first pick
 ```
 
 `@buf` on `sample` is a semantic error — buffer selection in `sample` is per-event inside the list.

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -398,11 +398,17 @@ How `sample`, `slice`, and `cloud` interpret their event lists and select SynthD
 
 Pattern-level buffer selection for `slice` and `cloud`.
 
-| Code                                        | Interpretation             | Evaluation                          | Result                                |
-| ------------------------------------------- | -------------------------- | ----------------------------------- | ------------------------------------- |
-| `@buf(\myloop) slice drums [0 2 4]`         | Static buffer.             | `\myloop` attached to all events.   | All slice events use `myloop` buffer. |
-| `@buf([\loopA \loopB]'pick) slice drums []` | Dynamic buffer, per-cycle. | Generator polled at cycle boundary. | Buffer alternates randomly per cycle. |
-| `@buf(\x) cloud grain []`                   | Buffer for cloud.          | `\x` attached to cloud event.       | `grainCloud` uses `x` buffer.         |
+The `@buf` argument may be a static `\symbol` or any sequence generator form — the same traversal modifiers (`'pick`, `'shuf`, sequential, `'lock`, `'eager`) apply as on any `[...]` list. The generator is polled **once per cycle**; all events within the cycle share the same buffer name.
+
+| Code                                            | Interpretation                   | Evaluation                                     | Result                                                         |
+| ----------------------------------------------- | -------------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
+| `@buf(\myloop) slice drums [0 2 4]`             | Static buffer.                   | `\myloop` attached to all events.              | All slice events use `myloop` buffer.                          |
+| `@buf([\loopA \loopB]'pick) slice drums []`     | Uniform random, per-cycle.       | Generator polled once at cycle boundary.       | Buffer chosen randomly each cycle; all events share same name. |
+| `@buf([\a \b \c]'shuf) slice drums []`          | Deck-shuffle, per-cycle.         | Visits all N buffers before repeating.         | Non-repeating until deck exhausted; then reshuffled.           |
+| `@buf([\loopA \loopB]) slice drums []`          | Sequential (default), per-cycle. | Cycle 0→loopA, cycle 1→loopB, cycle 2→loopA, … | Cycles through buffers in order.                               |
+| `@buf([\loopA \loopB]'lock) slice drums []`     | Frozen buffer.                   | First cycle picks a name; frozen thereafter.   | Same buffer for the entire session.                            |
+| `@buf([\loopA \loopB]'eager(4)) slice drums []` | Slow rotation, per 4 cycles.     | Buffer name changes every 4 cycles.            | Buffer held for 4 cycles, then advances.                       |
+| `@buf(\x) cloud grain []`                       | Buffer for cloud.                | `\x` attached to cloud event.                  | `grainCloud` uses `x` buffer.                                  |
 
 **Error cases**
 

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -3455,3 +3455,133 @@ describe("shape modifiers × 'stut composition (truth table 26)", () => {
 		expect(notes("note x [1 2 3 4]'rev'stut(2)")).toEqual([67, 67, 65, 65, 64, 64, 62, 62]);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 20. @buf with generator expression — per-cycle buffer selection (truth table 20, issue #40)
+// ---------------------------------------------------------------------------
+
+describe('@buf with generator expression — per-cycle buffer selection', () => {
+	// --- Static \symbol form (existing behaviour — must remain working) ---
+
+	it('@buf(\\myloop) sets bufferName on slice events (static, regression)', () => {
+		const evs = eval0('@buf(\\myloop) slice drums [0 2]') as SliceEvent[];
+		expect(evs[0].bufferName).toBe('myloop');
+		expect(evs[1].bufferName).toBe('myloop');
+	});
+
+	it('@buf(\\recording) sets bufferName on cloud event (static, regression)', () => {
+		const evs = eval0('@buf(\\recording) cloud grain []') as CloudEvent[];
+		expect(evs[0].bufferName).toBe('recording');
+	});
+
+	// --- Dynamic generator form — per-cycle buffer selection ---
+
+	it("@buf([\\loopA \\loopB]'pick) parses without error for slice", () => {
+		const i = createInstance("@buf([\\loopA \\loopB]'pick) slice drums [0 4 8 12]");
+		expect(i.ok).toBe(true);
+		if (!i.ok) return;
+		const r = i.evaluate({ cycleNumber: 0 });
+		expect(r.ok).toBe(true);
+	});
+
+	it("@buf([\\loopA \\loopB]'pick) bufferName is one of the two options each cycle", () => {
+		const i = inst("@buf([\\loopA \\loopB]'pick) slice drums [0 4]");
+		const seen = new Set<string>();
+		for (let c = 0; c < 50; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			const evs = r.events as SliceEvent[];
+			expect(evs.length).toBeGreaterThan(0);
+			for (const ev of evs) {
+				expect(['loopA', 'loopB']).toContain(ev.bufferName);
+				seen.add(ev.bufferName!);
+			}
+		}
+		// Over 50 cycles both names should appear (probabilistic but very reliable)
+		expect(seen.has('loopA')).toBe(true);
+		expect(seen.has('loopB')).toBe(true);
+	});
+
+	it('all slice events within one cycle share the same bufferName from @buf generator', () => {
+		// All events in a single cycle must use the same buffer name (sampled once per cycle)
+		const i = inst("@buf([\\loopA \\loopB]'pick) slice drums [0 4 8 12]");
+		for (let c = 0; c < 20; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			const evs = r.events as SliceEvent[];
+			const names = new Set(evs.map((e) => e.bufferName));
+			expect(names.size).toBe(1);
+		}
+	});
+
+	it("@buf([\\a \\b \\c]'shuf) slice — cycles through shuffled buffer names", () => {
+		const i = createInstance("@buf([\\a \\b \\c]'shuf) slice drums [0 4]");
+		expect(i.ok).toBe(true);
+		if (!i.ok) return;
+		const r = i.evaluate({ cycleNumber: 0 });
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const evs = r.events as SliceEvent[];
+		expect(['a', 'b', 'c']).toContain(evs[0].bufferName);
+	});
+
+	it('@buf([\\loopA \\loopB]) slice — cycles through buffers in order', () => {
+		// Default traversal: sequential. Cycle 0 → loopA, cycle 1 → loopB, cycle 2 → loopA, ...
+		const i = inst('@buf([\\loopA \\loopB]) slice drums [0 4]');
+		const r0 = i.evaluate({ cycleNumber: 0 });
+		const r1 = i.evaluate({ cycleNumber: 1 });
+		const r2 = i.evaluate({ cycleNumber: 2 });
+		if (!r0.ok || !r1.ok || !r2.ok) throw new Error('eval failed');
+		const name0 = (r0.events[0] as SliceEvent).bufferName;
+		const name1 = (r1.events[0] as SliceEvent).bufferName;
+		const name2 = (r2.events[0] as SliceEvent).bufferName;
+		expect(name0).toBe('loopA');
+		expect(name1).toBe('loopB');
+		expect(name2).toBe('loopA'); // wraps around
+	});
+
+	it("@buf([\\loopA \\loopB]'pick) cloud — bufferName set on cloud event", () => {
+		const i = inst("@buf([\\loopA \\loopB]'pick) cloud grain []");
+		for (let c = 0; c < 20; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			const evs = r.events as CloudEvent[];
+			expect(evs).toHaveLength(1);
+			expect(['loopA', 'loopB']).toContain(evs[0].bufferName);
+		}
+	});
+
+	it("@buf([\\loopA \\loopB]'lock) — buffer name is chosen once and frozen", () => {
+		// 'lock freezes the value on first evaluation
+		const i = inst("@buf([\\loopA \\loopB]'lock) slice drums [0 4]");
+		let lockedName: string | undefined;
+		for (let c = 0; c < 10; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			const evs = r.events as SliceEvent[];
+			const name = evs[0].bufferName;
+			if (lockedName === undefined) {
+				lockedName = name;
+			} else {
+				expect(name).toBe(lockedName);
+			}
+		}
+	});
+
+	it("@buf(\\myloop) — static form still uses 'lock semantics (same name every cycle)", () => {
+		const i = inst('@buf(\\myloop) slice drums [0 4]');
+		for (let c = 0; c < 5; c++) {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			const evs = r.events as SliceEvent[];
+			expect(evs[0].bufferName).toBe('myloop');
+		}
+	});
+
+	// --- Error cases ---
+
+	it('@buf on sample is still a semantic error', () => {
+		const i = createInstance("@buf([\\x \\y]'pick) sample drums [\\kick]");
+		expect(i.ok).toBe(false);
+	});
+});

--- a/src/lib/lang/evaluator.test.ts
+++ b/src/lib/lang/evaluator.test.ts
@@ -3584,4 +3584,20 @@ describe('@buf with generator expression — per-cycle buffer selection', () => 
 		const i = createInstance("@buf([\\x \\y]'pick) sample drums [\\kick]");
 		expect(i.ok).toBe(false);
 	});
+
+	it("@buf([\\loopA \\loopB]'eager(2)) slice — buffer advances every 2 cycles", () => {
+		// 'eager(2): polled at cycles 0, 2, 4, ... and held in between.
+		// Sequential poll: cycle 0 → idx 0 → loopA; cycle 2 → idx 1 → loopB; cycle 4 → idx 0 → loopA
+		const i = inst("@buf([\\loopA \\loopB]'eager(2)) slice drums [0 4]");
+		const getName = (c: number) => {
+			const r = i.evaluate({ cycleNumber: c });
+			if (!r.ok) throw new Error(r.error);
+			return (r.events[0] as SliceEvent).bufferName;
+		};
+		expect(getName(0)).toBe('loopA'); // first poll: idx 0
+		expect(getName(1)).toBe('loopA'); // held — no poll on odd cycles with period=2
+		expect(getName(2)).toBe('loopB'); // second poll: idx 1
+		expect(getName(3)).toBe('loopB'); // held
+		expect(getName(4)).toBe('loopA'); // third poll: idx 2 % 2 = 0 → loopA
+	});
 });

--- a/src/lib/lang/evaluator.ts
+++ b/src/lib/lang/evaluator.ts
@@ -1844,6 +1844,27 @@ type ArpConfig = {
 
 type ContentType = 'note' | 'mono' | 'sample' | 'slice' | 'cloud';
 
+/**
+ * A stateful runner that yields a buffer name string per cycle.
+ * `runner` yields an integer index (0..names.length-1) subject to EagerMode.
+ * `names` is the ordered list of buffer names the index refers to.
+ *
+ * For the static `@buf(\symbol)` form: names = [name], runner always yields 0 ('lock).
+ * For the dynamic `@buf([\a \b]'pick)` form: names = ['a','b'], runner yields a
+ * random index each cycle (or per lock/eager semantics).
+ */
+type BufRunner = {
+	runner: RunnerState; // yields integer index into `names`
+	names: string[]; // buffer name lookup table
+};
+
+/** Sample a BufRunner for the current cycle, returning the buffer name string. */
+function sampleBufRunner(br: BufRunner, cycle: number): string {
+	const idx = Math.round(sampleRunner(br.runner, cycle));
+	const n = br.names.length;
+	return br.names[((idx % n) + n) % n]; // safe modulo for any integer
+}
+
 type CompiledPattern = {
 	name: string; // generator name (mandatory since issue #2)
 	parentName: string | null; // parent name for derived (child:parent) generators; null = plain
@@ -1857,7 +1878,7 @@ type CompiledPattern = {
 	legatoRunner: RunnerState | null; // null = default legato (0.8 for note)
 	offsetRunner: RunnerState | null; // null = no offset
 	contentType: ContentType; // content type keyword
-	bufName: string | null; // buffer name from @buf decorator; null = use default
+	bufRunner: BufRunner | null; // @buf argument compiled to a per-cycle runner; null = use default buffer
 	numSlicesRunner: RunnerState | null; // 'numSlices modifier (slice only); null = not set
 	atOffset: number; // cycle offset from 'at modifier
 	repeat: number | null; // null = loop indefinitely, n = finite play count
@@ -1902,23 +1923,103 @@ function collectPatternModifiers(patternNode: CstNode): CstNode[] {
 }
 
 /**
- * Extract a \symbol argument from a @buf decorator in the given decorator layers.
- * Returns the buffer name (without leading \) if found, or null.
+ * Compile the @buf decorator argument from the given decorator layers into a BufRunner.
+ *
+ * Supports two forms:
+ *   1. Static:  `@buf(\myloop)` — a single \symbol token → constant runner, 'lock semantics.
+ *   2. Dynamic: `@buf([\loopA \loopB]'pick)` — a sequenceGenerator containing \symbol elements
+ *               with list modifiers ('pick, 'shuf, 'lock, 'eager, etc.).
+ *
+ * Returns null if no @buf decorator is present.
+ * Returns an error string if the @buf argument is malformed (e.g. no symbols found).
  */
-function extractBufName(decoratorLayers: CstNode[][]): string | null {
+function compileBufArg(decoratorLayers: CstNode[][]): BufRunner | null | string {
 	for (const layer of decoratorLayers) {
 		for (const dec of layer) {
 			const idToks = (dec.children.Identifier as IToken[]) ?? [];
 			if (idToks[0]?.image !== 'buf') continue;
-			// Found @buf — extract the \symbol argument
+
+			// Found @buf — inspect its decoratorArg children.
 			const args = (dec.children.decoratorArg as CstNode[]) ?? [];
 			for (const arg of args) {
+				// --- Form 1: static \symbol ---
 				const symTok = ((arg.children.Symbol as IToken[]) ?? [])[0];
-				if (symTok) return symTok.image.slice(1); // strip leading \
+				if (symTok) {
+					const name = symTok.image.slice(1); // strip leading \
+					// Static form uses 'lock semantics: always yields index 0.
+					const runner = makeRunner(() => 0, { kind: 'lock' });
+					return { runner, names: [name] };
+				}
+
+				// --- Form 2: sequenceGenerator [\symbol ...]'pick/'shuf/etc. ---
+				const seqGen = ((arg.children.sequenceGenerator as CstNode[]) ?? [])[0];
+				if (seqGen) {
+					return compileBufSequenceGenerator(seqGen);
+				}
 			}
 		}
 	}
 	return null;
+}
+
+/**
+ * Compile a sequenceGenerator CST node that contains \symbol elements into a BufRunner.
+ * The generator represents the @buf argument for per-cycle buffer selection.
+ *
+ * Supported modifiers on the list: 'pick (random), 'shuf (shuffle), 'lock, 'eager(n).
+ * Unsupported generator features inside the list (non-symbol elements) are silently skipped.
+ */
+function compileBufSequenceGenerator(seqGen: CstNode): BufRunner | string {
+	// Extract \symbol names from the sequenceElement children.
+	const elems = (seqGen.children.sequenceElement as CstNode[]) ?? [];
+	const names: string[] = [];
+	for (const elem of elems) {
+		const symTok = ((elem.children.Symbol as IToken[]) ?? [])[0];
+		if (symTok) names.push(symTok.image.slice(1));
+	}
+	if (names.length === 0) {
+		return '@buf sequence generator contains no \\symbol elements';
+	}
+
+	// Extract list-level modifiers from the sequenceGenerator node.
+	const listMods = (seqGen.children.modifierSuffix as CstNode[]) ?? [];
+	const mode = extractEagerMode(listMods) ?? DEFAULT_MODE;
+
+	// Determine traversal strategy from modifiers.
+	let traversal: TraversalMode = 'seq';
+	if (hasModifier(listMods, 'shuf')) traversal = 'shuf';
+	else if (hasModifier(listMods, 'pick')) traversal = 'pick';
+
+	const n = names.length;
+
+	let poll: PollFn;
+	if (traversal === 'pick') {
+		// Uniform random selection: yield a random integer in [0, n).
+		poll = () => Math.floor(Math.random() * n);
+	} else if (traversal === 'shuf') {
+		// Deck-style shuffle: visit all n indices in random order before repeating.
+		// Build a shuffled deck, step through it, reshuffle when exhausted.
+		const deck: number[] = Array.from({ length: n }, (_, i) => i);
+		let deckIdx = n; // start at n so first poll triggers a reshuffle
+		function shuffleDeck(): void {
+			for (let i = deck.length - 1; i > 0; i--) {
+				const j = Math.floor(Math.random() * (i + 1));
+				[deck[i], deck[j]] = [deck[j], deck[i]];
+			}
+			deckIdx = 0;
+		}
+		poll = () => {
+			if (deckIdx >= n) shuffleDeck();
+			return deck[deckIdx++];
+		};
+	} else {
+		// Sequential: maintain an incrementing counter.
+		let idx = 0;
+		poll = () => idx++ % n;
+	}
+
+	const runner = makeRunner(poll, mode);
+	return { runner, names };
 }
 
 /**
@@ -2109,8 +2210,10 @@ function compilePattern(
 					: 'note';
 
 	// @buf decorator: valid on slice and cloud; semantic error on sample
-	const bufName = decoratorLayers ? extractBufName(decoratorLayers) : null;
-	if (bufName !== null && contentType === 'sample') {
+	const bufResult = decoratorLayers ? compileBufArg(decoratorLayers) : null;
+	if (typeof bufResult === 'string') return bufResult; // propagate compile error
+	const bufRunner: BufRunner | null = bufResult;
+	if (bufRunner !== null && contentType === 'sample') {
 		return '@buf is not valid on sample — buffer selection in sample is per-event inside the list';
 	}
 
@@ -2180,7 +2283,7 @@ function compilePattern(
 		legatoRunner,
 		offsetRunner,
 		contentType,
-		bufName,
+		bufRunner,
 		numSlicesRunner,
 		atOffset,
 		repeat,
@@ -2666,12 +2769,16 @@ function evaluateCompiledPattern(
 		legatoRunner,
 		offsetRunner,
 		contentType,
-		bufName,
+		bufRunner,
 		numSlicesRunner,
 		atOffset,
 		repeat,
 		paramRunners
 	} = compiled;
+
+	// Sample the @buf runner once per cycle to get the buffer name for this cycle.
+	// All events in the cycle share this one buffer name.
+	const bufName: string | null = bufRunner ? sampleBufRunner(bufRunner, cycle) : null;
 
 	// Sample stutter count once per cycle
 	const stutCount = stutRunner ? Math.max(1, Math.round(sampleRunner(stutRunner, cycle))) : 1;

--- a/src/lib/lang/parser.test.ts
+++ b/src/lib/lang/parser.test.ts
@@ -1036,3 +1036,45 @@ describe("modifierSuffix — 'arp traversal modifier", () => {
 		expect(parseErrors).toHaveLength(0);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// @buf with generator expression — per-cycle buffer selection (issue #40)
+// ---------------------------------------------------------------------------
+
+describe('@buf — generator expression argument', () => {
+	it('parses @buf(\\myloop) — static symbol form', () => {
+		const { parseErrors, lexErrors } = parse('@buf(\\myloop) slice drums [0 2 4]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses @buf([\\loopA \\loopB]'pick) — list of symbols with 'pick modifier", () => {
+		const { parseErrors, lexErrors } = parse("@buf([\\loopA \\loopB]'pick) slice drums [0 4 8]");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it('parses @buf([\\loopA \\loopB]) — list of symbols with default (seq) traversal', () => {
+		const { parseErrors, lexErrors } = parse('@buf([\\loopA \\loopB]) slice drums [0 4]');
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses @buf([\\a \\b \\c]'shuf) — list of symbols with 'shuf modifier", () => {
+		const { parseErrors, lexErrors } = parse("@buf([\\a \\b \\c]'shuf) slice drums [0 4]");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses @buf([\\loopA \\loopB]'pick) on cloud", () => {
+		const { parseErrors, lexErrors } = parse("@buf([\\loopA \\loopB]'pick) cloud grain []");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+
+	it("parses @buf([\\loopA \\loopB]'lock) — list with 'lock modifier", () => {
+		const { parseErrors, lexErrors } = parse("@buf([\\loopA \\loopB]'lock) slice drums [0 4]");
+		expect(lexErrors).toHaveLength(0);
+		expect(parseErrors).toHaveLength(0);
+	});
+});

--- a/src/lib/lang/parser.ts
+++ b/src/lib/lang/parser.ts
@@ -442,7 +442,7 @@ class FluxParser extends CstParser {
 
 	decoratorArg = this.RULE('decoratorArg', () => {
 		// pitchClass (e.g. g#, Ab), bare identifier (e.g. minor, lydian), \symbol (e.g. \myloop),
-		// or numeric generator.
+		// numeric generator, or a sequence generator (for @buf([\loopA \loopB]'pick)).
 		this.OR([
 			// pitchClass: a single-char identifier [a-gA-G] optionally followed by Sharp/Flat
 			{
@@ -454,7 +454,13 @@ class FluxParser extends CstParser {
 			// Scale names and other bare identifiers (e.g. lydian, minor, dorian)
 			{ ALT: () => this.CONSUME(Identifier) },
 			// Numeric generator expressions: @root(3rand7), set tempo(120)
-			{ ALT: () => this.SUBRULE(this.numericGenerator) }
+			{ ALT: () => this.SUBRULE(this.numericGenerator) },
+			// Sequence generator: @buf([\loopA \loopB]'pick) — list of \symbol values with modifiers.
+			// `[` is unambiguous here since none of the other alternatives can start with `[`.
+			{
+				GATE: () => this.LA(1).tokenType === LBracket,
+				ALT: () => this.SUBRULE(this.sequenceGenerator)
+			}
 		]);
 	});
 


### PR DESCRIPTION
## Summary

Closes #40

- **Parser**: Extends `decoratorArg` to accept a `sequenceGenerator` (`[...]` list) as an alternative, enabling `@buf([\loopA \loopB]'pick)` and related forms to parse without errors.
- **Evaluator**: Replaces the static `extractBufName` (returns `string | null`) with `compileBufArg` (returns a `BufRunner | null`), where `BufRunner` is a new type pairing a numeric `RunnerState` (index) with a `string[]` lookup table. A `sampleBufRunner(br, cycle)` helper samples the runner and maps the index to a name.
- **Static form** (`@buf(\myloop)`) compiles to a constant `'lock` runner — same name every cycle (regression-safe).
- **Dynamic form** (`@buf([\loopA \loopB]'pick)`) supports `'pick` (uniform random), `'shuf` (deck-shuffle, non-repeating), sequential (default cycling), and all `'lock`/`'eager(n)` semantics from the EagerMode system.
- The buffer name is sampled **once per cycle**; all events within a cycle share the same buffer name (per spec truth table 20).

## Design decisions

- `RunnerState` remains numeric-only; strings are resolved via the `BufRunner.names` lookup table rather than introducing a new `StringRunnerState` type. This keeps the runner architecture uniform.
- `'shuf` on `@buf` uses a deck-shuffle (Fisher-Yates) with a stateful index, visiting all N buffers before repeating — same semantics as `'shuf` on sequence lists.
- `CompiledPattern.bufName: string | null` is replaced by `bufRunner: BufRunner | null`; the `string | null` form is reconstructed at evaluate-time by `sampleBufRunner`.

## Test plan

- [x] 5 new parser tests: `@buf([...])`, `@buf([...]'pick)`, `@buf([...]'shuf)`, `@buf([...]'lock)` on slice and cloud
- [x] 11 new evaluator tests: parse round-trip, random buffer selection, per-cycle consistency, sequential cycling, cloud support, `'lock` freeze, static form regression
- [x] All existing `@buf` static-form tests continue to pass
- [x] `pnpm check` — 0 errors
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)