### PR TITLE
fix: non-fatal layer errors (#43)

### DIFF
--- a/src/lib/gen.test.ts
+++ b/src/lib/gen.test.ts
@@ -174,13 +174,49 @@ describe('createGen() — basic emission', () => {
 		expect(realEvents(events)).toHaveLength(1);
 	});
 
-	it('stops and calls onMessage(error) when evaluator returns ok:false', () => {
+	it('skips the bad cycle (yields a skip stub) and calls onMessage(error) when evaluator returns ok:false', () => {
 		const onMessage = vi.fn();
-		const inst = fakeInst([makeEvent()], { failOnCycle: 0 });
+		// Cycle 0 fails, cycle 1+ succeeds — generator must continue
+		const inst = fakeInst([makeEvent()], { failOnCycle: 0, doneOnCycle: 2 });
 		const gen = createGen(makeDeps(inst, { onMessage }));
 		const events = take(gen, 100);
-		expect(events).toHaveLength(0);
+		// Cycle 0 skipped (1 skip stub), cycle 1 fires a real event
+		expect(realEvents(events)).toHaveLength(1);
 		expect(onMessage).toHaveBeenCalledWith(expect.stringContaining('Pattern error'), 'error');
+	});
+
+	it('yields a single skip stub covering exactly cycleBeatCount beats when a cycle fails', () => {
+		const onMessage = vi.fn();
+		// Cycle 0 fails — must yield exactly one skip stub of duration CB
+		const inst = fakeInst([makeEvent()], { failOnCycle: 0, doneOnCycle: 1 });
+		const gen = createGen(makeDeps(inst, { onMessage }));
+		const events = take(gen, 10);
+		// Cycle 0: one skip stub (whole cycle)
+		// Cycle 1: done → generator finishes
+		expect(events).toHaveLength(1);
+		expect(events[0].skip).toBe(true);
+		expect(events[0].duration).toBeCloseTo(CB);
+	});
+
+	it('continues producing events after a failed cycle', () => {
+		// Cycle 0 fails, cycles 1 and 2 succeed, cycle 3 done
+		const inst = fakeInst([makeEvent({ beatOffset: 0 })], { failOnCycle: 0, doneOnCycle: 3 });
+		const gen = createGen(makeDeps(inst));
+		const events = take(gen, 50);
+		// 2 successful cycles → 2 real events
+		expect(realEvents(events)).toHaveLength(2);
+	});
+
+	it('keeps cursor aligned after a skipped cycle — subsequent events have correct durations', () => {
+		// Cycle 0 fails (skip), cycle 1 has 2 events — total duration should be 2*CB
+		const inst = fakeInst([makeEvent({ beatOffset: 0 }), makeEvent({ beatOffset: 0.5 })], {
+			failOnCycle: 0,
+			doneOnCycle: 2
+		});
+		const gen = createGen(makeDeps(inst));
+		const events = take(gen, 30);
+		const total = events.reduce((s, e) => s + e.duration, 0);
+		expect(total).toBeCloseTo(CB * 2);
 	});
 
 	it('calls onMessage(info) when pattern finishes', () => {

--- a/src/lib/gen.ts
+++ b/src/lib/gen.ts
@@ -58,7 +58,14 @@ export function* createGen(deps: GenDeps): Generator<GenEvent> {
 		if (!result.ok) {
 			onMessage(`Pattern error in cycle ${cycleIdx}: ${result.error}`, 'error');
 			console.error('[gen] evaluate() failed:', result.error);
-			return;
+			// Skip this cycle: yield a silent stub covering the full cycle boundary
+			// so the scheduler cursor stays aligned, then continue to the next cycle.
+			const nextCycleBoundary = startBeat + (cycleIdx + 1) * cycleBeatCount;
+			const skipDuration = nextCycleBoundary - schedulerBeat;
+			yield { skip: true, duration: skipDuration };
+			schedulerBeat = nextCycleBoundary;
+			cycleIdx++;
+			continue;
 		}
 		if (result.done) {
 			onMessage('Pattern finished', 'info');

--- a/src/lib/scheduler.test.ts
+++ b/src/lib/scheduler.test.ts
@@ -648,18 +648,42 @@ describe('run() — callback exception handling', () => {
 		expect(onError).toHaveBeenCalledWith(expect.stringContaining('boom'));
 	});
 
-	it('stops the scheduler when the callback throws', () => {
-		vi.spyOn(clock, 'beatToAudioTime').mockImplementation(boundedBeatMock(3));
+	it('continues scheduling subsequent events after the callback throws (non-fatal)', () => {
+		// The callback throws on the first event but the scheduler must continue
+		// and deliver all remaining events in the lookahead window.
+		// Use beat-aware mock: beats 0, 1, 2 all in-window; beat 3+ out-of-window.
+		vi.spyOn(clock, 'beatToAudioTime').mockImplementation((beat: number) =>
+			beat < 3 ? fakeCurrentTime : fakeCurrentTime + LOOKAHEAD_SECONDS + 1
+		);
 
 		const callback = vi.fn().mockImplementationOnce(() => {
-			throw new Error('stop me');
+			throw new Error('non-fatal error');
 		});
 		const onError = vi.fn();
 
 		run(finiteGen([{ duration: 1 }, { duration: 1 }, { duration: 1 }]), callback, 1, 0, onError);
 
-		// Callback threw on first call — should not be called again
-		expect(callback).toHaveBeenCalledTimes(1);
+		// Callback threw on first call — subsequent events must still be delivered
+		expect(callback).toHaveBeenCalledTimes(3);
+		expect(onError).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not set active=false after a callback exception — timer is still scheduled', () => {
+		// After a callback throws, the scheduler must not stop. Verify by checking
+		// that a new timer was scheduled (the tick loop continues) even after an exception.
+		// We put the only event out-of-window so the loop exits normally (not via exception),
+		// then verify that the exception on a prior tick didn't kill the timer.
+		vi.spyOn(clock, 'beatToAudioTime').mockImplementation(boundedBeatMock(1));
+
+		const callback = vi.fn().mockImplementationOnce(() => {
+			throw new Error('recoverable');
+		});
+		const onError = vi.fn();
+
+		run(finiteGen([{ duration: 1 }, { duration: 1 }]), callback, 1, 0, onError);
+
+		// Callback threw and scheduler continued past it. Timer should be scheduled for next tick.
+		expect(vi.getTimerCount()).toBeGreaterThan(0);
 		expect(onError).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -115,8 +115,7 @@ export function run<T>(
 				const errMsg = `Scheduler error at beat ${nextBeat}: ${msg}`;
 				console.error(errMsg, e);
 				onError?.(errMsg);
-				active = false;
-				return;
+				// Non-fatal: log the error and skip this event, but keep running.
 			}
 			nextBeat += dur;
 			try {


### PR DESCRIPTION
## Summary

- **`gen.ts`**: when `evaluate()` returns `ok: false` for a cycle, the generator now skips that cycle (yields a `skip: true` stub covering the full `cycleBeatCount` beats to keep the scheduler cursor aligned) and continues to the next cycle. The error is reported via `onMessage` as before.
- **`scheduler.ts`**: when the event callback throws (e.g. OSC encoding error), the error is logged via `onError` and the event is skipped, but the scheduler remains active and continues scheduling subsequent events. Clock failures and zero/invalid durations remain fatal (unrecoverable).

## What did NOT change
- Parse/static errors (caught by `createInstance` before scheduling) still block evaluation of the affected layer — no change needed there
- `+page.svelte` log wiring was already correct; errors already display in the feedback panel
- Clock failures and invalid durations still stop the scheduler (unrecoverable conditions)

## Design decisions
- A failed cycle emits exactly one `skip: true` stub of `cycleBeatCount` beats, keeping the timing cursor aligned for subsequent cycles
- Callback exceptions are non-fatal at the scheduler level; only the specific event is dropped
- The existing `onMessage` / `onError` hooks already surface these to the UI feedback log

Closes #43

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>