### PR TITLE
docs: complete DSL reference for all built-in constructs (#45)

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -944,7 +944,7 @@ Placement **after a non-generator token is a syntax error**. In particular, a mo
 | Code                 | Failure                                                                 |
 | -------------------- | ----------------------------------------------------------------------- |
 | `note'legato(0.8)`   | Syntax error — `note` alone is a content-type keyword, not a generator. |
-| `note"amp(0.5)`      | Syntax error — `"param` requires a preceding generator expression.      |
+| `note lead"amp(0.5)` | Syntax error — `"param` requires a preceding generator expression.      |
 | `'stut(2)`           | Syntax error — no preceding token to attach to (see truth table 1).     |
 | `note [0] +'stut(2)` | Syntax error — the transposition operator is not a generator.           |
 
@@ -1003,17 +1003,17 @@ Continuation lines are currently modifier-only; `"param` does not have a continu
 The token form is `"` immediately followed by an identifier, with no whitespace — analogous to `\symbol`. The `"identifier` is a single token.
 
 ```flux
-note [0 2 4]"amp(0.5)            // set amp to 0.5
-note [0 2 4]"amp(0.5)"pan(-0.3)  // chained: set amp and pan
-note [0 2 4] | fx(\lpf)"cutoff(800)"rq(0.3)  // on FX node
+note lead [0 2 4]"amp(0.5)            // set amp to 0.5
+note lead [0 2 4]"amp(0.5)"pan(-0.3)  // chained: set amp and pan
+note bass [0 2 4] | fx(\lpf)"cutoff(800)"rq(0.3)  // on FX node
 ```
 
 The value argument accepts the same expressions as modifiers — literals, generators, stochastic expressions:
 
 ```flux
-note [0 2 4]"amp(0.3rand0.8)              // stochastic amp, eager(1) by default
-note [0 2 4]"amp(0.3rand0.8'eager(4))     // redraw every 4 cycles
-note [0 2 4]"amp(0.3rand0.8'lock)         // freeze at first drawn value
+note pad [0 2 4]"amp(0.3rand0.8)              // stochastic amp, eager(1) by default
+note pad [0 2 4]"amp(0.3rand0.8'eager(4))     // redraw every 4 cycles
+note pad [0 2 4]"amp(0.3rand0.8'lock)         // freeze at first drawn value
 ```
 
 **SynthDef parameter names** come from the SynthDef's `specs` object in `static/compiled_synthdefs/metadata.json`. Each key is a parameter name (e.g. `amp`, `pan`, `rel`); the value carries `{ default, min, max, unit, curve }`. The active SynthDef is determined by the `\symbol` argument on the content type keyword (`note(\kick)` → look up `kick`). Parameter names are lowercase identifiers.

--- a/docs/DSL-truthtables.md
+++ b/docs/DSL-truthtables.md
@@ -422,21 +422,21 @@ The `@buf` argument may be a static `\symbol` or any sequence generator form —
 
 Direct SynthDef argument access. Valid wherever modifiers are valid.
 
-| Code                                    | Interpretation              | Evaluation                           | Result                       |
-| --------------------------------------- | --------------------------- | ------------------------------------ | ---------------------------- |
-| `note [0 2 4]"amp(0.5)`                 | Set `amp` to literal.       | Value passed straight to synth node. | Amplitude fixed at 0.5.      |
-| `note [0 2 4]"amp(0.5)"pan(-0.3)`       | Chained params.             | Each param applied independently.    | Both amp and pan set.        |
-| `note [0 2 4]"amp(0.3rand0.8)`          | Stochastic value, eager(1). | Value drawn once per cycle.          | Amplitude varies per cycle.  |
-| `note [0 2 4]"amp(0.3rand0.8'eager(4))` | Redraw every 4 cycles.      | Value held 4 cycles then redrawn.    | Slowly varying amplitude.    |
-| `note [0 2 4]"amp(0.3rand0.8'lock)`     | Frozen value.               | Drawn once at first eval, frozen.    | Same amplitude forever.      |
-| `note [0 2 4] \| fx(\lpf)"cutoff(800)`  | Param on FX node.           | cutoff passed to FX synth node.      | Filter cutoff set to 800 Hz. |
+| Code                                        | Interpretation              | Evaluation                           | Result                       |
+| ------------------------------------------- | --------------------------- | ------------------------------------ | ---------------------------- |
+| `note lead [0 2 4]"amp(0.5)`                | Set `amp` to literal.       | Value passed straight to synth node. | Amplitude fixed at 0.5.      |
+| `note lead [0 2 4]"amp(0.5)"pan(-0.3)`      | Chained params.             | Each param applied independently.    | Both amp and pan set.        |
+| `note pad [0 2 4]"amp(0.3rand0.8)`          | Stochastic value, eager(1). | Value drawn once per cycle.          | Amplitude varies per cycle.  |
+| `note pad [0 2 4]"amp(0.3rand0.8'eager(4))` | Redraw every 4 cycles.      | Value held 4 cycles then redrawn.    | Slowly varying amplitude.    |
+| `note pad [0 2 4]"amp(0.3rand0.8'lock)`     | Frozen value.               | Drawn once at first eval, frozen.    | Same amplitude forever.      |
+| `note bass [0 2 4] \| fx(\lpf)"cutoff(800)` | Param on FX node.           | cutoff passed to FX synth node.      | Filter cutoff set to 800 Hz. |
 
 **Error cases**
 
-| Code                 | Failure Type | Why                                                     |
-| -------------------- | ------------ | ------------------------------------------------------- |
-| `"amp` alone         | Parse error  | Param token has no preceding expression to attach to.   |
-| `note [0]" amp(0.5)` | Lex error    | Whitespace between `"` and identifier is not permitted. |
+| Code                      | Failure Type | Why                                                     |
+| ------------------------- | ------------ | ------------------------------------------------------- |
+| `"amp` alone              | Parse error  | Param token has no preceding expression to attach to.   |
+| `note lead [0]" amp(0.5)` | Lex error    | Whitespace between `"` and identifier is not permitted. |
 
 ---
 

--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -1,0 +1,111 @@
+# Buffers
+
+Buffers are audio files loaded into the scsynth engine. They are used by `sample`, `slice`, and `cloud` content types.
+
+---
+
+## Loading buffers
+
+Open the **Sample panel** in the sidebar and drag-and-drop audio files (WAV, AIFF, MP3, OGG). Each loaded file gets a name (derived from the filename) and a buffer ID allocated by the registry.
+
+Loaded buffers persist for the session. Removing a buffer from the panel sends a `b_free` OSC message to release the memory in scsynth.
+
+---
+
+## Referencing buffers
+
+Buffers are referenced by their **name** as a `\symbol`:
+
+```flux
+sample drums [\kick \hat \snare \hat]
+```
+
+The name must match the name shown in the Sample panel exactly (case-sensitive).
+
+---
+
+## `sample` — per-event buffer selection
+
+Each element in the list is a `\symbol` naming a buffer. The runtime looks up the buffer ID from the registry for each event.
+
+```flux
+sample drums [\kick \hat \snare \hat]
+sample drums [\kick \hat]'pick      // random pick each time
+sample drums [\kick \snare]'shuf    // deck-shuffle
+```
+
+---
+
+## `@buf` — pattern-level buffer selection for `slice` and `cloud`
+
+`@buf(\name)` binds a single buffer to the whole pattern for one cycle. All events in that cycle share the same buffer.
+
+```flux
+@buf(\amen) slice drums [0 4 8 12]'numSlices(16)
+@buf(\recording) cloud grain []
+```
+
+The buffer name can be selected dynamically per cycle using sequence generators:
+
+```flux
+@buf([\loopA \loopB]'pick)    slice drums [0..15]   // random per cycle
+@buf([\loopA \loopB])         slice drums [0..15]   // sequential cycling
+@buf([\loopA \loopB]'shuf)    slice drums [0..15]   // deck-shuffle per cycle
+@buf([\loopA \loopB]'lock)    slice drums [0..15]   // frozen at first pick
+@buf([\loopA \loopB]'eager(4)) slice drums [0..15]  // change every 4 cycles
+```
+
+The generator is polled **once per cycle** — not once per event.
+
+---
+
+## Beat slicing with `slice`
+
+`slice` divides a buffer into equal-length slices and plays individual slices by index. Use `'numSlices(n)` to tell the SynthDef how many slices the buffer is divided into.
+
+```flux
+@buf(\amen) slice drums [0 4 8 12]'numSlices(16)   // 16-slice grid
+@buf(\amen) slice drums [0..15]'numSlices(16)      // all 16 slices in order
+@buf(\amen) slice drums [0..15]'pick'numSlices(16) // random slice each event
+```
+
+Slice indices are integers starting at 0.
+
+---
+
+## Granular synthesis with `cloud`
+
+`cloud` uses a persistent granular synth node. The event list is empty (`[]`) — parameters are modulated via `"param` each cycle.
+
+```flux
+@buf(\recording) cloud grain []"density(8)"pos(0.5rand0.8)
+```
+
+Key params for `grainCloud`: `density` (grains per second), `pos` (playback position 0.0–1.0).
+
+---
+
+## Channel count and SynthDef variant selection
+
+At event dispatch, the runtime checks the buffer's channel count and selects the appropriate SynthDef variant:
+
+| Channels | Variant selected                             |
+| -------- | -------------------------------------------- |
+| Mono     | `samplePlayer_mono` / `slicePlayer_mono`     |
+| Stereo   | `samplePlayer_stereo` / `slicePlayer_stereo` |
+
+If no variant exists for the channel count, the event is skipped with a logged error. `grainCloud` only exists as a `_mono` variant — stereo buffers fall back to mono with a warning.
+
+---
+
+## Buffer names in the DSL
+
+Buffer names follow the `\symbol` convention — a backslash immediately followed by an identifier, no space:
+
+```flux
+\kick          // buffer named "kick"
+\amen          // buffer named "amen"
+\myRecording   // buffer named "myRecording"
+```
+
+The backslash distinguishes buffer names (runtime artefacts) from bare identifiers (built-in language vocabulary like scale names). String literals (`"kick"`) are not valid in Flux — always use `\symbol`.

--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -30,7 +30,7 @@ Each element in the list is a `\symbol` naming a buffer. The runtime looks up th
 
 ```flux
 sample drums [\kick \hat \snare \hat]
-sample drums [\kick \hat]'pick      // random pick each time
+sample drums [\kick \hat]'pick      // random pick each cycle
 sample drums [\kick \snare]'shuf    // deck-shuffle
 ```
 

--- a/docs/content-types.md
+++ b/docs/content-types.md
@@ -87,7 +87,7 @@ Default SynthDef: `grainCloud`. Like `mono`, `cloud` maintains a single node per
 
 ## Timing
 
-One DSL **cycle** is one bar (4 beats). Each element in the list gets an equal time slice: `[0 2 4]` gives each note ⅓ of a cycle.
+A **cycle** is the DSL's repeating unit of time — the pattern's list is distributed across it, and the cycle loops. Its wall-clock duration depends on the global tempo/time signature and is not fixed to any specific beat count. Each element in the list gets an equal time slice: `[0 2 4]` gives each note ⅓ of a cycle.
 
 Sublists subdivide their parent slot:
 

--- a/docs/content-types.md
+++ b/docs/content-types.md
@@ -1,0 +1,172 @@
+# Content Types
+
+The first keyword on a pattern line is the **content type** — it determines what kind of events the pattern generates.
+
+```flux
+note  lead [0 2 4]        // polyphonic pitched events
+mono  bass [0 -2 0 -3]    // monophonic pitched events
+sample drums [\kick \hat \snare \hat]   // buffer playback by name
+slice  amen [0 4 8 12]'numSlices(16)    // beat-sliced buffer
+cloud  grain []                          // granular synthesis
+```
+
+A **name** is required between the content type and the generator — `note [0 2 4]` without a name is a parse error.
+
+---
+
+## `note` — polyphonic pitched events
+
+Spawns a new synth instance for every event. Each instance is self-releasing: a gate-close message is sent after the event's time slot × the legato factor. This matches standard SuperCollider `Pbind` conventions.
+
+```flux
+note lead [0 2 4]              // default: loops forever
+note lead [0 2 4 7]'n(2)       // play 2 cycles then stop
+note lead [<0 4 7>]            // chord: three simultaneous voices
+```
+
+Default SynthDef: `fm`. Override with `note(\mySynth) lead [...]`.
+
+Default legato: **0.8** (gate closes at 80 % of the event slot). Override with `'legato(n)`.
+
+---
+
+## `mono` — monophonic pitched events
+
+Maintains a single persistent synth node per named pattern. The first cycle spawns the node; subsequent cycles send `.set` messages to update parameters in place. No re-spawning — no audible click on pitch change.
+
+```flux
+mono bass [0 -2 0 -3]          // smooth pitch updates
+mono bass [0 2 4]'stut          // each pitch sent twice
+```
+
+`'legato` has no effect on `mono` — the node is persistent and legato as overlap-control is undefined.
+
+`<>` chord syntax is a semantic error on `mono` — multiple simultaneous `.set` messages with different degrees produce non-deterministic behaviour.
+
+---
+
+## `sample` — buffer playback by name
+
+Each event in the list is a `\symbol` that names a loaded buffer. The runtime looks up the buffer ID from the registry and passes it to the SynthDef.
+
+```flux
+sample drums [\kick \hat \snare \hat]
+sample drums [\kick \hat]'stut(2)
+```
+
+Default SynthDef: `samplePlayer`. The runtime selects `samplePlayer_mono` or `samplePlayer_stereo` based on the buffer's channel count. Override the SynthDef with `sample(\mySampler) drums [...]`.
+
+`@buf` is a semantic error on `sample` — buffer selection is per-event, inside the list.
+
+---
+
+## `slice` — beat-sliced buffer playback
+
+Each event is an integer slice index into a fixed buffer. Use `'numSlices(n)` to tell the SynthDef how many slices the buffer is divided into.
+
+```flux
+@buf(\amen) slice drums [0 4 8 12]'numSlices(16)
+@buf([\loopA \loopB]'pick) slice drums [0..15]'numSlices(16)
+```
+
+Default SynthDef: `slicePlayer`. The `@buf` decorator (required) selects which buffer to slice. Per-cycle buffer selection is supported — see [Decorators](decorators).
+
+---
+
+## `cloud` — granular synthesis
+
+A persistent granular synth node, updated via `.set` messages each cycle. The event list is empty (`[]`) — parameters are controlled via `"param` notation.
+
+```flux
+@buf(\recording) cloud grain []"density(8)"pos(0.5rand0.8)
+```
+
+Default SynthDef: `grainCloud`. Like `mono`, `cloud` maintains a single node per name. Parameters can be modulated stochastically.
+
+---
+
+## Timing
+
+One DSL **cycle** is one bar (4 beats). Each element in the list gets an equal time slice: `[0 2 4]` gives each note ⅓ of a cycle.
+
+Sublists subdivide their parent slot:
+
+```flux
+note lead [0 1 [2 3] 4]
+// 0, 1, 4 get 1/4 cycle each
+// 2, 3 each get 1/8 cycle (half of the 1/4 slot)
+```
+
+### Finite playback: `'n`
+
+```flux
+note lead [0 2 4]'n       // play once (= 'n(1))
+note lead [0 2 4]'n(4)    // play 4 cycles then stop
+```
+
+### Phase offset: `'at`
+
+```flux
+note lead [0 2 4]'at(1/4)     // start 1/4 cycle into the bar
+note lead [0 2 4]'at(1/2)     // loop, phase-shifted half a bar
+note lead [0 2 4]'n'at(1/4)   // play once, starting 1/4 in
+```
+
+`'at` is cycle-relative. Use `'offset` for millisecond nudges on individual events.
+
+### Timing nudge: `'offset`
+
+```flux
+note lead [0 1 2]'offset(20)    // all events 20 ms late (humanise)
+note lead [0 1 2]'offset(-10)   // all events 10 ms early
+```
+
+### Legato: `'legato`
+
+Controls how long each note gate stays open, as a fraction of the event slot.
+
+```flux
+note lead [0 2 4]'legato(0.8)               // default
+note lead [0 2 4]'legato(1.5)               // overlapping (pad-style)
+note lead [0 2 4]'legato(0.5rand1.2)        // stochastic legato
+```
+
+Values > 1.0 create overlap, useful for pads and drones.
+
+---
+
+## SynthDef selection
+
+All content types accept an optional `\symbol` argument to select the SynthDef:
+
+```flux
+note(\moog) lead [0 1 2 3]
+sample(\oneshot) drums [\kick \hat]
+```
+
+---
+
+## FX insert
+
+Pipe `|` attaches insert FX to any pattern:
+
+```flux
+note lead [0 2 4] | fx(\lpf)'cutoff(800)
+note lead [0 2 4] | fx(\delay)'time(3/8)'feedback(0.4)
+note lead [0 2 4] | fx(\lpf)'cutoff(800) 50%   // 50% wet
+```
+
+See [SynthDefs](synthdefs) for more on FX.
+
+---
+
+## Derived patterns
+
+A pattern can inherit from another with `child:parent` syntax:
+
+```flux
+sample drums [\kick \hat \snare]
+sample perc:drums 'at(1/8) | fx(\hpf)
+```
+
+`perc` inherits `drums`'s pattern and params, overriding only what is explicitly written.

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -64,11 +64,11 @@ Accepts an integer 0–11 or a stochastic generator.
 
 ---
 
-### `@oct` / `@octave` — octave
+### `@octave` — octave
 
 ```flux
-@oct(4)     // octave 4 (one below default 5)
-@oct(6)     // octave 6
+@octave(4)     // octave 4 (one below default 5)
+@octave(6)     // octave 6
 ```
 
 ---

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -1,0 +1,166 @@
+# Decorators
+
+Decorators set pitch context and buffer selection for patterns. They are written with a leading `@` and use a parenthesised argument list.
+
+```flux
+@key(g# minor)
+  note lead [0 2 4]
+```
+
+Decorators can scope a block (indented body) or apply inline to a single expression.
+
+---
+
+## Pitch decorators
+
+These decorators control the degree-to-frequency chain:
+
+```
+degree → scale → root → octave → cent → frequency
+```
+
+### `@key` — compound pitch context
+
+Sets root, scale, and optionally octave together. The most common way to establish key.
+
+```flux
+@key(g# minor)           // root = G#, scale = minor; octave defaults to 5
+@key(g# lydian 4)        // root = G#, scale = lydian, octave = 4
+@key(c major)            // root = C, scale = major
+```
+
+`set key(...)` is equivalent at global scope:
+
+```flux
+set key(g# minor)
+```
+
+**Root names** use lowercase letter + optional accidental: `c`, `d`, `e`, `f`, `g`, `a`, `b`, `c#`, `db`, `f#`, `gb`, `g#`, `ab`, `a#`, `bb`.
+
+**Scale names** include at minimum: `major`, `minor`, `dorian`, `phrygian`, `lydian`, `mixolydian`, `locrian`, `pentatonic_major`, `pentatonic_minor`, `chromatic`, `whole_tone`.
+
+---
+
+### `@scale` — scale only
+
+```flux
+@scale(dorian)
+  note lead [0 2 4 5 7]
+
+@scale(minor) note lead [0 2 4]   // inline
+```
+
+---
+
+### `@root` — root note (semitones from C)
+
+```flux
+@root(7)              // root = G (7 semitones from C)
+@root(3rand7)         // stochastic root, eager by default
+@root(3rand7'lock)    // root chosen once and frozen
+```
+
+Accepts an integer 0–11 or a stochastic generator.
+
+---
+
+### `@oct` / `@octave` — octave
+
+```flux
+@oct(4)     // octave 4 (one below default 5)
+@oct(6)     // octave 6
+```
+
+---
+
+### `@cent` — fine pitch deviation
+
+Deviates pitch by the given number of cents (100 cents = 1 semitone). Default: 0.
+
+```flux
+@cent(10)           // 10 cents sharp
+@cent(-20)          // 20 cents flat
+@cent(-50rand50)    // random detuning each cycle
+```
+
+---
+
+## Scoped blocks
+
+Decorators can scope a block of expressions using indentation:
+
+```flux
+@scale(minor) @root(7)
+  note lead [0 1 2]
+  @oct(4)
+    note bass [0 2 4 5]
+```
+
+- `note lead [0 1 2]` inherits `scale=minor` and `root=7`.
+- `note bass [0 2 4 5]` inherits all three, with `octave=4` added.
+
+Indentation uses **2-space units**. The block closes when indentation returns to the enclosing level.
+
+For a single expression, decorators can appear inline on the same line:
+
+```flux
+@scale(minor) note lead [0 1 2]
+```
+
+---
+
+## `set` — global session state
+
+`set` is `@` at global scope — it establishes session-wide defaults that all patterns inherit unless overridden.
+
+```flux
+set scale(minor)
+set root(7)
+set tempo(120)
+set key(g# lydian)
+```
+
+Parameters: `scale`, `root`, `octave`, `tempo`, `cent`, `key`.
+
+---
+
+## `@buf` — buffer selection for `slice` and `cloud`
+
+`@buf(\name)` specifies which buffer a `slice` or `cloud` pattern operates on. Written inline before the content type keyword.
+
+```flux
+@buf(\myloop) slice drums [0 2 4 8]
+@buf(\recording) cloud grain []
+```
+
+**Static buffer:**
+
+```flux
+@buf(\myloop) slice drums [0 2 4 8]'numSlices(16)
+```
+
+**Per-cycle buffer selection:** `@buf` accepts any sequence generator, polled once per cycle. All events within the cycle share the same buffer.
+
+```flux
+@buf([\loopA \loopB]'pick)    slice drums [0 4 8 12]   // random per cycle
+@buf([\a \b \c]'shuf)         slice drums [0 4 8 12]   // deck-shuffle
+@buf([\loopA \loopB])         slice drums [0 4 8 12]   // sequential cycling
+@buf([\loopA \loopB]'lock)    slice drums [0 4 8 12]   // frozen after first pick
+@buf([\loopA \loopB]'eager(4)) slice drums [0 4 8 12]  // changes every 4 cycles
+```
+
+`@buf` on `sample` is a semantic error — buffer selection in `sample` is per-event inside the list.
+
+---
+
+## Stochastic decorator arguments
+
+Decorator arguments follow the same `'lock`/`'eager(n)` semantics as any other generator:
+
+```flux
+@root(3rand7)           // new root each cycle
+@root(3rand7'lock)      // root drawn once when block is first entered, frozen thereafter
+@root(3rand7'eager(4))  // new root every 4 cycles
+```
+
+`'lock` is the sensible default for decorators — a randomly wandering root is an opt-in, not the default.

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -1,0 +1,295 @@
+# Generators
+
+Generators are objects that yield a stream of values. They are the building blocks of every pattern — the sequence list `[...]`, random expressions, byte encodings, and arithmetic on top of them.
+
+Generators are evaluated **eagerly at cycle boundaries**, never mid-cycle. The full event array is calculated once per cycle and handed to the scheduler as a concrete sequence.
+
+---
+
+## Sequence lists `[...]`
+
+The fundamental generator. By default it yields its elements in order, cycling back to the start.
+
+```flux
+[1 2 3]          // yields 1, 2, 3, 1, 2, 3, …
+[0 _ 4]          // rest on the 2nd slot — _ is silence
+[0 [2 3] 4]      // sublist: 2 and 3 share the time of one slot
+```
+
+Elements are separated by **spaces** — commas are not valid separators.
+
+### Rests `_`
+
+`_` occupies a time slot without spawning a synth. It can appear anywhere an element can appear.
+
+```flux
+note lead [0 _ 2 _ 4]    // alternating notes and silences
+```
+
+### Traversal modifiers
+
+Attach modifiers to `[...]` to change traversal:
+
+| Modifier | Behaviour                                                         |
+| -------- | ----------------------------------------------------------------- |
+| `'pick`  | Pick one element at random each cycle                             |
+| `'shuf`  | Shuffle the deck then traverse in order, reshuffle when exhausted |
+| `'arp`   | Arpeggiate — see below                                            |
+
+```flux
+[1 2 3]'pick       // uniform random each cycle
+[1 2?2 3]'pick     // weighted: 2 appears twice as often
+[1 2 3]'shuf       // like Pshuf — deck-shuffled
+```
+
+### Weighted random `'pick`
+
+Add `?weight` after any element to bias selection. Weights are non-negative number literals (not generators). Missing weights default to 1.
+
+```flux
+[1 2?3 3?0]'pick   // 1 gets weight 1, 2 gets weight 3, 3 is never picked
+[x?0 y?0]'pick     // all zero weights → silent slot (rest)
+```
+
+---
+
+## Range notation `[start..end]`
+
+Compact syntax for integer or float sequences. Ranges are expanded to a flat list at compile time.
+
+```flux
+[0..7]             // [0 1 2 3 4 5 6 7]
+[0, 2..10]         // [0 2 4 6 8 10]  (explicit step)
+[0.0, 0.25..1.0]   // [0.0 0.25 0.5 0.75 1.0]
+[10, 8..0]         // [10 8 6 4 2 0]  (descending)
+[5..0]             // [5 4 3 2 1 0]   (auto-descending)
+```
+
+Both bounds are **inclusive**. Float ranges require an explicit step — `[0.0..1.0]` is a parse error.
+
+Ranges can carry the usual list modifiers:
+
+```flux
+[0..15]'pick               // random slice from 0–15
+[0..7]'shuf                // shuffled 0–7
+slice drums [0..15]'numSlices(16)    // all 16 slices
+```
+
+---
+
+## Random generators
+
+All random generators produce a single value per poll (they are **scalar generators**). Write them with no whitespace: `0rand4`, not `0 rand 4`.
+
+### White noise `rand` / `~`
+
+Uniform random integer (or float) between min and max.
+
+```flux
+0rand4     // integer in {0, 1, 2, 3, 4} — equivalent to Pwhite(0, 4)
+0~4        // shorthand for rand
+0.rand4    // float in [0.0, 4.0) — either bound as float → continuous output
+```
+
+When either bound is a float, the output is a continuous float. In a degree context (inside `[...]`), floats are rounded to the nearest integer before scale lookup. Float bounds are most useful in non-degree contexts like `'legato(0.5rand1.2)`.
+
+### Gaussian noise `gau`
+
+Normal distribution with mean and standard deviation.
+
+```flux
+0gau4      // Pgauss(mean=0, sdev=4)
+4gau0.5    // mean=4, sdev=0.5 — tight cluster around 4
+```
+
+### Exponential random `exp`
+
+Exponentially distributed value between min and max. Sounds more natural for frequencies and amplitudes.
+
+```flux
+1exp7      // Pexprand(min=1, max=7)
+100exp4000 // useful for filter cutoff
+```
+
+### Brownian noise `bro`
+
+Random walk (Brownian motion) bounded between min and max, with a configurable maximum step.
+
+```flux
+0bro10m2   // Pbrown(min=0, max=10, maxStep=2)
+```
+
+Syntax: `min bro max m maxStep`. The `m` separator is part of the generator syntax — no whitespace.
+
+---
+
+## Deterministic generators
+
+### Linear series `step`
+
+Arithmetic series: start, start+step, start+2×step, …
+
+```flux
+0step2x4   // Pseries(start=0, step=2, length=4) → 0, 2, 4, 6
+```
+
+Syntax: `start step stepSize x length`. Cycles after length elements. Stateful — loops from start when exhausted.
+
+### Geometric series `mul`
+
+Geometric series: start, start×mul, start×mul², …
+
+```flux
+1mul2x4    // Pgeom(start=1, multiplier=2, length=4) → 1, 2, 4, 8
+5mul0.5x4  // 5, 2.5, 1.25, 0.625
+```
+
+Syntax: `start mul multiplier x length`.
+
+### Linear interpolation `lin`
+
+Evenly spaced values from first to last.
+
+```flux
+2lin7x8    // [2.0, 2.71, 3.43, 4.14, 4.86, 5.57, 6.29, 7.0] (8 values)
+0lin1x5    // [0.0, 0.25, 0.5, 0.75, 1.0]
+```
+
+Syntax: `first lin last x length`.
+
+### Geometric interpolation `geo`
+
+Exponentially spaced values from first to last.
+
+```flux
+2geo7x8    // 8 values from 2 to 7, geometrically spaced
+1geo100x5  // 1, ~3.16, ~10, ~31.6, 100
+```
+
+Syntax: `first geo last x length`.
+
+---
+
+## UTF-8 byte generator `utf8{word}`
+
+Converts the characters of an identifier to their UTF-8 byte values and yields them in sequence, cycling indefinitely.
+
+```flux
+note lead utf8{coffee} % 14
+// "coffee" → bytes [99 111 102 102 101 101] → % 14 → [1 7 4 4 3 3]
+
+note lead [utf8{hello} % 7 0 2]
+// nested as a scalar inside a sequence list
+```
+
+- `utf8` must be immediately followed by `{` with no whitespace.
+- The content inside `{}` is a single bare identifier (letters, digits, underscores).
+- Combined with `%` (modulo), byte values map into a useful scale-degree range.
+- `utf8{word}` is a scalar generator — it yields one integer per poll.
+
+---
+
+## Generator nesting
+
+Generators can be used as inputs to other generators using parentheses:
+
+```flux
+(0rand2)rand4    // lower bound is itself random: Pwhite(Pwhite(0,2), 4)
+```
+
+Without parentheses, `0rand2rand4` is a semantic error — ambiguous chaining requires explicit grouping.
+
+Generators can also appear inside sequence lists:
+
+```flux
+[0 1exp7 4gau2]   // Pseq([0, Pexprand(1,7), Pgauss(4,2)])
+```
+
+---
+
+## Generator arithmetic
+
+Arithmetic operators apply element-wise to the values produced by the left-hand generator:
+
+| Operator | Meaning        | Example             |
+| -------- | -------------- | ------------------- |
+| `+`      | Addition       | `[0 2 4] + 2`       |
+| `-`      | Subtraction    | `[0 2 4] - 1`       |
+| `*`      | Multiplication | `[0 2 4] * 2`       |
+| `/`      | Division       | `[0 2 4] / 2`       |
+| `**`     | Exponentiation | `[0 2 4] ** 2`      |
+| `%`      | Modulo         | `utf8{coffee} % 14` |
+
+```flux
+note lead [0 2 4] + 2        // shift all degrees up 2 scale steps
+note lead [0 2 4] + 0rand3   // stochastic transposition, redrawn each cycle
+note lead [0 1 2] + [4 8]    // list RHS: pos i uses rhs[i % rhs_length]
+                              // → 4, 9, 6
+```
+
+**Division by zero** skips that event slot with a warning. **Modulo zero** is defined as identity (`a % 0 = a`).
+
+`note [0] - -4` is a parse error — use `note [0] + 4` instead.
+
+---
+
+## Chord literals `<...>`
+
+`<d1 d2 ... dn>` denotes N simultaneous degree values in one event slot. All voices fire at the same beat offset.
+
+```flux
+note chords [<0 2 4>]           // one slot: triad (root, 3rd, 5th)
+note chords [<0 4 7> <1 3 6>]   // two chord slots
+note chords [<0 4~7> 2]         // chord with a random voice
+```
+
+Chords are not supported for `mono` — they produce a semantic error.
+
+---
+
+## Accidentals
+
+Write accidentals directly on degree integers — no space:
+
+```flux
+2b   // third, flat
+4#   // fifth, sharp
+3bb  // third, double flat
+4##  // fifth, double sharp
+
+note lead [0 2b 4 6#]
+```
+
+---
+
+## `'lock` and `'eager(n)`
+
+Control how often a generator is resampled:
+
+| Annotation  | Behaviour                                       |
+| ----------- | ----------------------------------------------- |
+| `'eager(1)` | Resample every cycle (default)                  |
+| `'eager(n)` | Resample every n cycles                         |
+| `'lock`     | Sample once at first evaluation, freeze forever |
+
+```flux
+note lead [0rand7]             // new value each cycle (default)
+note lead [0rand7]'eager(4)    // new value every 4 cycles
+note lead [0rand7]'lock        // frozen at first-drawn value
+
+// element-level override:
+note lead [0rand7'lock 4rand6] // first frozen, second eager
+```
+
+Inner annotations override outer ones.
+
+---
+
+## Custom event timing `@`
+
+Schedule an element at an absolute position within the cycle (0 = cycle start, 1 = one full cycle):
+
+```flux
+note lead [0@0 4@1/4 7@5/8]    // absolute positions
+note lead [0 4 7@1/2]          // 0 and 4 use natural spacing; 7 forced to 1/2
+```

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -16,7 +16,7 @@ The fundamental generator. By default it yields its elements in order, cycling b
 [0 [2 3] 4]      // sublist: 2 and 3 share the time of one slot
 ```
 
-Elements are separated by **spaces** — commas are not valid separators.
+Elements are separated by **spaces** — commas are not valid separators, except inside range expressions (see below).
 
 ### Rests `_`
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,72 @@
+# Get Started
+
+Flux is a live coding environment for stochastic music. You write patterns in the Flux DSL, evaluate them with **Ctrl+Enter**, and the audio engine plays them in sync — looping, updating, or stopping in real time.
+
+## Boot the engine
+
+Click **boot engine** in the sidebar, or press **Ctrl+B**. The engine initialises the Web Audio / scsynth WASM runtime. Audio only starts after a user interaction — this is a browser requirement, not a Flux limitation.
+
+## Your first pattern
+
+```flux
+note lead [0 2 4]
+```
+
+This plays a major triad, looping indefinitely. Breaking it down:
+
+- `note` — the content type: polyphonic pitched events
+- `lead` — a name for this pattern (required)
+- `[0 2 4]` — a sequence of scale degrees: root, 2nd degree, 4th degree
+
+Each element takes an equal slice of one **cycle** (the global time unit). With three elements, each note lasts ⅓ of a cycle.
+
+## Evaluate
+
+Press **Ctrl+Enter** with your cursor anywhere in the editor to evaluate the whole buffer. Changes take effect at the next cycle boundary — you will never hear a glitch.
+
+Press **Ctrl+.** (period) to stop all patterns.
+
+## Add randomness
+
+```flux
+note lead [0rand4 2 4]
+```
+
+`0rand4` is a random integer generator: each cycle it draws a new value uniformly between 0 and 4. The sequence changes every cycle but stays in the same rhythmic slot.
+
+## Stack patterns
+
+```flux
+note lead [0 2 4]
+note bass [0]
+```
+
+Each named pattern runs independently. Evaluate both lines at once and they loop in sync.
+
+## Set the key
+
+```flux
+set key(g# minor)
+
+note lead [0 2 4 5]
+```
+
+`set key(...)` establishes root, scale, and optionally octave for all patterns below it. You can override per-pattern with an `@key(...)` decorator.
+
+## Control and keyboard shortcuts
+
+| Key        | Action            |
+| ---------- | ----------------- |
+| Ctrl+B     | Boot audio engine |
+| Ctrl+Enter | Evaluate buffer   |
+| Ctrl+.     | Stop all patterns |
+
+## Next steps
+
+- [Content Types](content-types) — `note`, `mono`, `sample`, `slice`, `cloud`
+- [Generators](generators) — random, deterministic, and sequencing generators
+- [Modifiers](modifiers) — shape, repeat, and time your sequences
+- [Params](params) — direct SynthDef argument access with `"param`
+- [Decorators](decorators) — pitch context (`@key`, `@scale`, `@root`, `@oct`) and buffer selection (`@buf`)
+- [SynthDefs](synthdefs) — choosing and writing synthesis engines
+- [Buffers](buffers) — loading and using audio samples

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -1,0 +1,271 @@
+# Modifiers
+
+Modifiers are stream and generator operations written with a leading `'`. They attach to the immediately preceding generator expression and return `this`, so they can be chained.
+
+```flux
+[0 2 4]'stut(2)'lock    // stutter, then freeze the count
+```
+
+The `'` must be written directly adjacent to the modifier name — no whitespace between them.
+
+---
+
+## List traversal modifiers
+
+These attach to `[...]` lists and change how elements are selected each cycle.
+
+### `'pick` — random selection
+
+Picks one element at random each cycle. See [Generators](generators) for weighted `?` syntax.
+
+```flux
+[1 2 3]'pick          // uniform random
+[1 2?3 3]'pick        // weighted: 2 picked 3× more often
+```
+
+### `'shuf` — deck shuffle
+
+Shuffles the list, traverses in order, then reshuffles when exhausted. Every element is heard before repeating — unlike `'pick`.
+
+```flux
+[1 2 3]'shuf          // like Pshuf
+```
+
+### `'arp` — arpeggiation
+
+Collects the cycle's output values, removes duplicates, filters rests, and traverses them melodically.
+
+```flux
+[0..10]'arp               // sorted ascending (default \up)
+[0..10]'arp(\down)        // sorted descending
+[0..10]'arp(\updown)      // palindrome: ascending then descending, no repeated endpoints
+[0..10]'arp(\inward)      // pincer: outer pairs toward middle
+[0..10]'arp(\outward)     // starts at middle, expands outward
+[0..10]'arp(\down 16)     // \down traversal cycled to 16 values
+```
+
+**Algorithms:**
+
+| Symbol                  | Traversal                                   |
+| ----------------------- | ------------------------------------------- |
+| `\up`                   | Sorted ascending (default)                  |
+| `\down`                 | Sorted descending                           |
+| `\updown`               | Ascending then descending; length = 2×(N−1) |
+| `\inward` / `\converge` | Pincer from both ends toward middle         |
+| `\outward` / `\diverge` | Starts at middle, expands outward           |
+
+**Rules:**
+
+- Duplicates are removed before arpeggiation (preserving first-occurrence order).
+- Rests are filtered out. If all elements are rests, one rest event is emitted.
+- `'arp` on a single element is a no-op.
+- `'arp` cannot be combined with `'shuf` or `'pick` — choose one traversal strategy.
+
+**Grammar:** `'arp` | `'arp(\symbol)` | `'arp(\symbol integer)`
+
+---
+
+## Sequence shape modifiers
+
+These reshape the event array for a cycle **after** traversal, before scheduling. Applied after `'shuf`/`'pick`/`'arp`.
+
+### `'rev` — reverse
+
+Reverses the event array.
+
+```flux
+[1 2 3 4]'rev       // plays as [4 3 2 1]
+[1~4]'rev           // reverses this cycle's random draws
+```
+
+`'rev` on a single element is a no-op.
+
+### `'mirror` — palindrome with repeated endpoints
+
+Appends the reverse without its first element: `[a b c]` → `[a b c b a]`. Natural length = 2N − 1.
+
+```flux
+[1 2 3]'mirror      // plays as [1 2 3 2 1]
+[1 2]'mirror        // plays as [1 2 1]
+```
+
+Both endpoints appear twice. Single element is a no-op.
+
+### `'bounce` — palindrome without repeated endpoints
+
+Appends the reverse with both endpoints removed: `[a b c]` → `[a b c b]`. Natural length = 2(N − 1).
+
+```flux
+[1 2 3]'bounce      // plays as [1 2 3 2]
+[1 2]'bounce        // plays as [1 2]   (nothing to append for 2-element)
+```
+
+No endpoint repeats. Single element is a no-op.
+
+**Composition with `'stut`:** shape modifiers apply before `'stut`.
+
+```flux
+[1 2 3]'mirror'stut(2)   // mirror first (5 events), then stutter each → 10 events
+```
+
+---
+
+## Repetition modifiers
+
+### `'stut(n)` — stutter
+
+Repeats every event n times within the cycle. Default n = 2.
+
+```flux
+[0 2 4]'stut           // each element repeated 2×
+[0 2 4]'stut(4)        // each element repeated 4×
+[0 2 4]'stut(2rand4)   // random count, redrawn each cycle (default eager(1))
+```
+
+The stutter count is drawn at the start of each cycle by default. Use `'eager` or `'lock` to control this:
+
+```flux
+[0 2 4]'stut(2rand4'eager(4))   // count redrawn every 4 cycles
+[0 2 4]'stut(2rand4'lock)       // count frozen at first-drawn value
+```
+
+Count must be ≥ 1. `'stut(0)` and `'stut(-1)` are semantic errors. Count argument must be a scalar generator — a list argument is a semantic error.
+
+**`'stut` on `mono`:** sends n repeated `.set` messages to the persistent node. Audibility depends on the SynthDef.
+
+### `'spread` — expand to sibling slots
+
+Expands a multi-value generator's iteration into multiple consecutive slots within the parent list. The generator is a **per-element modifier** — it attaches to an element inside `[...]`, not to the outer list.
+
+```flux
+// step generator of length 4 → 4 sibling slots
+note lead [0step1x4'spread]        // equivalent to [0 1 2 3]
+
+// explicit count
+note lead [0step1x4'spread(2)]     // take 2 values → [0 1]
+
+// list element
+note lead [A [0 2 4]'spread]       // A + 3 spread values = 4 slots
+
+// scalar with explicit count
+note lead [4'spread(3)]            // three copies of 4 → [4 4 4]
+```
+
+**Bare `'spread` on a scalar** (literal, `rand`, `gau`, etc.) is a no-op with a console warning — scalars have no natural iteration length. Use `'spread(n)` to poll n times.
+
+`'spread` on a top-level list (no enclosing `[...]`) is a semantic error — there are no sibling slots to spread into.
+
+**Interaction with `'stut`:**
+
+```flux
+[0step1x4'spread]'stut(2)   // spread (4 slots) then stutter each → 8 events
+```
+
+---
+
+## Probability modifier
+
+### `'maybe(p)` — probabilistic gate
+
+Passes each event through with probability p (0.0–1.0) and skips it otherwise. Default p = 0.5.
+
+```flux
+[0 2 4]'maybe          // each event 50% likely to fire
+[0 2 4]'maybe(0.75)    // each event 75% likely
+```
+
+---
+
+## Timing modifiers
+
+### `'n(count)` — finite playback
+
+Play the pattern a fixed number of cycles then stop. Default (bare `'n`) = 1 cycle.
+
+```flux
+note lead [0 2 4]'n       // play once
+note lead [0 2 4]'n(4)    // play 4 cycles
+```
+
+Count must be a positive integer ≥ 1.
+
+### `'at(phase)` — phase offset
+
+Shift when the pattern starts within the cycle. Phase is cycle-relative (0–1).
+
+```flux
+note lead [0 2 4]'at(1/4)     // start 1/4 cycle into the bar
+note lead [0 2 4]'at(-1/8)    // start 1/8 cycle before the bar
+note lead [0 2 4]'at(1/2)     // loop, phase-shifted half a cycle
+```
+
+### `'offset(ms)` — millisecond timing nudge
+
+Shifts all events a fixed number of milliseconds. Positive = late, negative = early. Useful for humanising or correcting latency.
+
+```flux
+note lead [0 1 2]'offset(20)    // 20 ms late
+note lead [0 1 2]'offset(-10)   // 10 ms early
+```
+
+`'offset` must be a scalar value — a list generator argument is a semantic error.
+
+### `'legato(factor)` — note duration
+
+Controls how long each note gate stays open as a fraction of the event slot. Only affects `note`; no effect on `mono`.
+
+```flux
+note lead [0 2 4]'legato(0.8)            // default
+note lead [0 2 4]'legato(1.5)            // overlapping (pad)
+note lead [0 2 4]'legato(0.5rand1.2)     // stochastic legato
+```
+
+Values > 1.0 produce overlap. Zero and negative values are semantic errors.
+
+---
+
+## Resampling control
+
+### `'eager(n)` — resample every n cycles
+
+The default for all generators. The cycle count must be a positive integer ≥ 1.
+
+```flux
+note lead [0rand7]'eager(1)    // redraw every cycle (default; bare 'eager is shorthand)
+note lead [0rand7]'eager(4)    // redraw every 4 cycles
+```
+
+### `'lock` — freeze forever
+
+Sample once at the first cycle and never redraw.
+
+```flux
+note lead [0rand7]'lock          // frozen at first-drawn value
+note lead [0rand7'lock 4rand6]   // element-level: first frozen, second eager
+```
+
+Inner annotations override outer ones: `[0rand7'lock 4rand6]'eager(4)` — first element ignores the outer `eager(4)` and stays locked.
+
+---
+
+## `'numSlices(n)` — slice grid size
+
+For `slice` content type only. Tells the SynthDef how many slices the buffer is divided into.
+
+```flux
+@buf(\amen) slice drums [0 4 8 12]'numSlices(16)
+```
+
+---
+
+## Modifier continuation lines
+
+To apply a modifier to the whole content-type expression (including a transposition operand), write it on an indented continuation line:
+
+```flux
+note lead [0 2 4] + 0rand3
+  'stut(2)
+  'legato(0.8)
+```
+
+Each continuation line begins with `'` and attaches to the content-type expression as a whole, in order. This is the only way to reach the whole-expression attachment point.

--- a/docs/params.md
+++ b/docs/params.md
@@ -1,0 +1,76 @@
+# Params
+
+The `"param` notation sends a value directly to a named SynthDef argument, bypassing all of Flux's musical abstractions.
+
+The token is `"` immediately followed by an identifier — no whitespace — analogous to `\symbol` names.
+
+```flux
+note lead [0 2 4]"amp(0.5)
+```
+
+---
+
+## Syntax
+
+```flux
+note [0 2 4]"amp(0.5)            // set amp to 0.5
+note [0 2 4]"amp(0.5)"pan(-0.3)  // chain multiple params
+note [0 2 4] | fx(\lpf)"cutoff(800)"rq(0.3)   // on an FX node
+```
+
+`"param` attaches to the immediately preceding generator expression, just like modifiers. The quote character `"` must not have whitespace before the identifier name.
+
+---
+
+## Stochastic values
+
+The value argument accepts the same expressions as modifiers — literals, generators, and stochastic expressions:
+
+```flux
+note [0 2 4]"amp(0.3rand0.8)              // random each cycle (eager(1) by default)
+note [0 2 4]"amp(0.3rand0.8'eager(4))     // new value every 4 cycles
+note [0 2 4]"amp(0.3rand0.8'lock)         // frozen at first drawn value
+```
+
+---
+
+## Available parameters
+
+Parameter names come from the SynthDef's specification. The common built-in parameters are:
+
+| Parameter | Range      | Description                  |
+| --------- | ---------- | ---------------------------- |
+| `amp`     | 0.0 – 1.0  | Output amplitude (linear)    |
+| `pan`     | −1.0 – 1.0 | Stereo position; 0 = centre  |
+| `freq`    | 20 – 20000 | Oscillator frequency in Hz   |
+| `cutoff`  | 20 – 20000 | Filter cutoff frequency (Hz) |
+| `res`     | 0.0 – 1.0  | Filter resonance             |
+
+The exact set of available parameters depends on the active SynthDef. Use `note(\mySynth)` to target a specific def, then `"param` to access its arguments.
+
+---
+
+## On FX nodes
+
+`"param` applies equally to patterns and FX nodes:
+
+```flux
+note lead [0 2 4] | fx(\lpf)"cutoff(1200)"rq(0.2)
+note lead [0 2 4] | fx(\delay)"time(3/8)"feedback(0.45)
+```
+
+---
+
+## Design intent
+
+`"param` is intentionally unglamorous. It is the escape hatch for raw SynthDef access when a higher-level abstraction does not exist. Heavy reliance on `"param` is a signal to consider elevating the parameter to a first-class concept or redesigning the SynthDef.
+
+The three sigils serve distinct, non-overlapping roles:
+
+| Sigil | Role      | What it does                                              |
+| ----- | --------- | --------------------------------------------------------- |
+| `@`   | Decorator | Musical pitch context (`root`, `scale`, `octave`, `cent`) |
+| `'`   | Modifier  | Event stream and generator behaviour                      |
+| `"`   | Param     | Direct SynthDef argument passthrough                      |
+
+No sigil can substitute for another. `'amp(0.5)` is not valid — `amp` is a SynthDef argument, not a stream modifier.

--- a/docs/params.md
+++ b/docs/params.md
@@ -13,9 +13,9 @@ note lead [0 2 4]"amp(0.5)
 ## Syntax
 
 ```flux
-note [0 2 4]"amp(0.5)            // set amp to 0.5
-note [0 2 4]"amp(0.5)"pan(-0.3)  // chain multiple params
-note [0 2 4] | fx(\lpf)"cutoff(800)"rq(0.3)   // on an FX node
+note lead [0 2 4]"amp(0.5)            // set amp to 0.5
+note lead [0 2 4]"amp(0.5)"pan(-0.3)  // chain multiple params
+note bass [0 2 4] | fx(\lpf)"cutoff(800)"rq(0.3)   // on an FX node
 ```
 
 `"param` attaches to the immediately preceding generator expression, just like modifiers. The quote character `"` must not have whitespace before the identifier name.
@@ -27,9 +27,9 @@ note [0 2 4] | fx(\lpf)"cutoff(800)"rq(0.3)   // on an FX node
 The value argument accepts the same expressions as modifiers — literals, generators, and stochastic expressions:
 
 ```flux
-note [0 2 4]"amp(0.3rand0.8)              // random each cycle (eager(1) by default)
-note [0 2 4]"amp(0.3rand0.8'eager(4))     // new value every 4 cycles
-note [0 2 4]"amp(0.3rand0.8'lock)         // frozen at first drawn value
+note pad [0 2 4]"amp(0.3rand0.8)              // random each cycle (eager(1) by default)
+note pad [0 2 4]"amp(0.3rand0.8'eager(4))     // new value every 4 cycles
+note pad [0 2 4]"amp(0.3rand0.8'lock)         // frozen at first drawn value
 ```
 
 ---

--- a/docs/synthdefs.md
+++ b/docs/synthdefs.md
@@ -1,0 +1,123 @@
+# SynthDefs
+
+SynthDefs are the synthesis engines that Flux patterns drive. Flux ships its own SynthDef library compiled from SuperCollider `.scd` files.
+
+---
+
+## Selecting a SynthDef
+
+All content types accept an optional `\symbol` argument to choose the SynthDef:
+
+```flux
+note(\moog) lead [0 1 2 3]
+sample(\oneshot) drums [\kick \hat]
+mono(\pad) bass [0 -2 0 -3]
+```
+
+Without an explicit `\symbol`, the default SynthDef for the content type is used:
+
+| Content type    | Default SynthDef |
+| --------------- | ---------------- |
+| `note` / `mono` | `fm`             |
+| `sample`        | `samplePlayer`   |
+| `slice`         | `slicePlayer`    |
+| `cloud`         | `grainCloud`     |
+
+---
+
+## Built-in instrument SynthDefs
+
+The following SynthDefs ship with Flux. Their available `"param` names and ranges are visible in the SynthDef panel in the sidebar.
+
+### `fm` — FM synthesis (default)
+
+The default tonal synth for `note` and `mono`. Supports standard pitch via `freq` and a gated envelope via `gate`.
+
+Key params: `amp`, `pan`, `freq`, `gate`.
+
+### `samplePlayer` — one-shot sample playback
+
+Used by the `sample` content type. The runtime selects `samplePlayer_mono` or `samplePlayer_stereo` based on the loaded buffer's channel count.
+
+Key params: `amp`, `pan`, `buf`, `gate`.
+
+### `slicePlayer` — beat-slicer playback
+
+Used by the `slice` content type. The `sliceIndex` and `numSlices` params control playback position.
+
+Key params: `amp`, `pan`, `buf`, `sliceIndex`, `numSlices`, `gate`.
+
+### `grainCloud` — granular synthesis
+
+Used by the `cloud` content type. Persistent node updated via `.set` messages.
+
+Key params: `amp`, `pan`, `buf`, `density`, `pos`, `gate`.
+
+---
+
+## Insert FX
+
+Insert FX are pattern-scoped and attached with the `|` pipe operator:
+
+```flux
+note lead [0 2 4 7] | fx(\lpf)'cutoff(800)
+note lead [0 2 4 7] | fx(\delay)'time(3/8)'feedback(0.4)
+note lead [0 2 4 7] | fx(\lpf)'cutoff(800) 50%   // 50% wet, 30% dry
+```
+
+The pipe operator implicitly routes the pattern's audio output into the FX node.
+
+**Wet/dry level** is an optional integer percentage after all parameter modifiers. Default: 100% wet.
+
+**Silence tail** — FX nodes run until silence after their source stops. Default: 5 seconds. Override with `'tail`:
+
+```flux
+note lead [0 2 4] | fx(\lpf)'cutoff(1200)'tail(10)   // 10s tail
+note lead [0 2 4] | fx(\lpf)'cutoff(1200)'tail(0)    // free immediately
+```
+
+### Built-in FX SynthDefs
+
+| Name       | Description                                   |
+| ---------- | --------------------------------------------- |
+| `\lpf`     | Low-pass filter. Key params: `cutoff`, `res`  |
+| `\hpf`     | High-pass filter. Key params: `cutoff`, `res` |
+| `\delay`   | Delay line. Key params: `time`, `feedback`    |
+| `\ringmod` | Ring modulator                                |
+
+---
+
+## Master bus FX
+
+A default master bus chain is set up at engine boot:
+
+1. EQ
+2. Reverb
+3. Dynamics (compressor + limiter)
+
+The master bus chain is configured in the **FX panel** in the sidebar — not from the DSL. The DSL has no syntax for master bus FX.
+
+---
+
+## Channel-count variant selection
+
+At event dispatch, the runtime looks up the active buffer's channel count and selects the appropriate SynthDef variant:
+
+- Mono buffer → `samplePlayer_mono`
+- Stereo buffer → `samplePlayer_stereo`
+
+If no variant exists for the detected channel count, the event is skipped with a logged error.
+
+`grainCloud` only exists as a `_mono` variant — if a stereo buffer is selected, a warning is logged and the mono variant is used.
+
+---
+
+## Writing custom SynthDefs
+
+Custom SynthDefs are compiled from SuperCollider `.scd` files. Each def must:
+
+- Declare `type: \instrument` or `type: \fx` in metadata.
+- Include `out` (output bus) and `amp` for instruments; `in`, `out`, `gate` for insert FX.
+- Use `gate` + a sustained envelope (ADSR) if the runtime should release the node.
+
+The compile script reads metadata from the `.scd` file and emits `metadata.json`. Place compiled `.scsyndef` files in `static/compiled_synthdefs/`. See `docs/SynthDef-spec.md` for the full authoring specification.

--- a/docs/synthdefs.md
+++ b/docs/synthdefs.md
@@ -62,7 +62,7 @@ Insert FX are pattern-scoped and attached with the `|` pipe operator:
 ```flux
 note lead [0 2 4 7] | fx(\lpf)'cutoff(800)
 note lead [0 2 4 7] | fx(\delay)'time(3/8)'feedback(0.4)
-note lead [0 2 4 7] | fx(\lpf)'cutoff(800) 50%   // 50% wet, 30% dry
+note lead [0 2 4 7] | fx(\lpf)'cutoff(800) 50%   // 50% wet, 50% dry
 ```
 
 The pipe operator implicitly routes the pattern's audio output into the FX node.

--- a/src/lib/DocsSidebar.svelte
+++ b/src/lib/DocsSidebar.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	interface Props {
+		active?: string;
+	}
+
+	const { active = '' }: Props = $props();
+
+	const sections = [
+		{ id: 'get-started', label: 'Get Started', href: resolve('/docs/get-started') },
+		{ id: 'content-types', label: 'Content Types', href: resolve('/docs/content-types') },
+		{ id: 'generators', label: 'Generators', href: resolve('/docs/generators') },
+		{ id: 'modifiers', label: 'Modifiers', href: resolve('/docs/modifiers') },
+		{ id: 'params', label: 'Params', href: resolve('/docs/params') },
+		{ id: 'decorators', label: 'Decorators', href: resolve('/docs/decorators') },
+		{ id: 'synthdefs', label: 'SynthDefs', href: resolve('/docs/synthdefs') },
+		{ id: 'buffers', label: 'Buffers', href: resolve('/docs/buffers') }
+	];
+</script>
+
+<nav class="docs-sidebar">
+	<p class="sidebar-heading">Reference</p>
+	<ul>
+		{#each sections as section (section.id)}
+			<li>
+				<a href={section.href} class:active={active === section.id}>
+					{section.label}
+				</a>
+			</li>
+		{/each}
+	</ul>
+</nav>
+
+<style>
+	.docs-sidebar {
+		width: 160px;
+		flex-shrink: 0;
+		position: sticky;
+		top: var(--space-5);
+	}
+
+	.sidebar-heading {
+		font-size: var(--text-xs);
+		font-weight: var(--weight-semibold);
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		margin: 0 0 var(--space-2) 0;
+	}
+
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	a {
+		display: block;
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+		text-decoration: none;
+		padding: var(--space-1) var(--space-2);
+		border-radius: var(--radius-sm);
+		transition: color var(--duration-fast) var(--ease-smooth);
+	}
+
+	a:hover {
+		color: var(--text-primary);
+		background: var(--surface-1);
+	}
+
+	a.active {
+		color: var(--text-primary);
+		background: var(--surface-2);
+	}
+</style>

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -36,7 +36,7 @@
 			href: resolve('/docs/decorators'),
 			label: 'Decorators',
 			description:
-				'@key, @scale, @root, @oct, @cent, @buf — pitch context and buffer selection for scoped blocks.'
+				'@key, @scale, @root, @octave, @cent, @buf — pitch context and buffer selection for scoped blocks.'
 		},
 		{
 			href: resolve('/docs/synthdefs'),

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -1,19 +1,259 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import SiteHeader from '$lib/SiteHeader.svelte';
-	import Spec from '$docs/DSL-spec.md';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+
+	const sections = [
+		{
+			href: resolve('/docs/get-started'),
+			label: 'Get Started',
+			description: 'Boot the engine, evaluate your first pattern, and learn the keyboard shortcuts.'
+		},
+		{
+			href: resolve('/docs/content-types'),
+			label: 'Content Types',
+			description:
+				'note, mono, sample, slice, cloud — what kind of events each type generates and how timing works.'
+		},
+		{
+			href: resolve('/docs/generators'),
+			label: 'Generators',
+			description:
+				'Sequence lists, random noise, deterministic series, UTF-8 byte encoding, and arithmetic operators.'
+		},
+		{
+			href: resolve('/docs/modifiers'),
+			label: 'Modifiers',
+			description:
+				"'stut, 'pick, 'shuf, 'arp, 'rev, 'mirror, 'bounce, 'spread, 'legato, 'lock, 'eager — shape and control your event stream."
+		},
+		{
+			href: resolve('/docs/params'),
+			label: 'Params',
+			description: '"param — direct SynthDef argument access, bypassing musical abstractions.'
+		},
+		{
+			href: resolve('/docs/decorators'),
+			label: 'Decorators',
+			description:
+				'@key, @scale, @root, @oct, @cent, @buf — pitch context and buffer selection for scoped blocks.'
+		},
+		{
+			href: resolve('/docs/synthdefs'),
+			label: 'SynthDefs',
+			description:
+				'Selecting synthesis engines, insert FX, master bus FX, and writing custom SynthDefs.'
+		},
+		{
+			href: resolve('/docs/buffers'),
+			label: 'Buffers',
+			description: 'Loading audio files, referencing by name, beat slicing, and granular synthesis.'
+		}
+	];
 </script>
 
 <div class="docs-page">
 	<SiteHeader />
-	<main class="prose">
-		<Spec />
-	</main>
+	<div class="docs-layout">
+		<DocsSidebar active="" />
+		<main class="prose">
+			<h1>Flux DSL Reference</h1>
+			<p>
+				Complete reference documentation for the Flux live coding language. Each section covers
+				syntax, semantics, and examples for one area of the DSL.
+			</p>
+
+			<div class="toc-grid">
+				{#each sections as section (section.href)}
+					<a class="toc-card" href={section.href}>
+						<h2>{section.label}</h2>
+						<p>{section.description}</p>
+					</a>
+				{/each}
+			</div>
+
+			<h2>Quick reference</h2>
+
+			<h3>Sigils</h3>
+			<table>
+				<thead>
+					<tr>
+						<th>Sigil</th>
+						<th>Role</th>
+						<th>What it does</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>@</code></td>
+						<td>Decorator</td>
+						<td>Pitch context — sets root, scale, octave, cent; or selects a buffer with @buf</td>
+					</tr>
+					<tr>
+						<td><code>'</code></td>
+						<td>Modifier</td>
+						<td>Transforms the event stream or controls generator behaviour</td>
+					</tr>
+					<tr>
+						<td><code>"</code></td>
+						<td>Param</td>
+						<td>Direct SynthDef argument passthrough</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<h3>Content types</h3>
+			<table>
+				<thead>
+					<tr>
+						<th>Keyword</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr><td><code>note</code></td><td>Polyphonic pitched events — new synth per event</td></tr
+					>
+					<tr
+						><td><code>mono</code></td><td
+							>Monophonic — single persistent node, pitch updated via .set</td
+						></tr
+					>
+					<tr
+						><td><code>sample</code></td><td
+							>Buffer playback by name — per-event buffer selection</td
+						></tr
+					>
+					<tr
+						><td><code>slice</code></td><td>Beat-sliced buffer playback — integer slice indices</td
+						></tr
+					>
+					<tr
+						><td><code>cloud</code></td><td
+							>Granular synthesis — persistent node, modulated via .set</td
+						></tr
+					>
+				</tbody>
+			</table>
+
+			<h3>Random generators</h3>
+			<table>
+				<thead>
+					<tr>
+						<th>Syntax</th>
+						<th>Distribution</th>
+						<th>Example</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						><td><code>min rand max</code></td><td>Uniform random</td><td><code>0rand4</code></td
+						></tr
+					>
+					<tr
+						><td><code>min ~ max</code></td><td>Uniform random (shorthand)</td><td
+							><code>0~4</code></td
+						></tr
+					>
+					<tr><td><code>mean gau sdev</code></td><td>Gaussian</td><td><code>0gau4</code></td></tr>
+					<tr><td><code>min exp max</code></td><td>Exponential</td><td><code>1exp7</code></td></tr>
+					<tr
+						><td><code>min bro max m step</code></td><td>Brownian walk</td><td
+							><code>0bro10m2</code></td
+						></tr
+					>
+				</tbody>
+			</table>
+
+			<h3>Deterministic generators</h3>
+			<table>
+				<thead>
+					<tr>
+						<th>Syntax</th>
+						<th>Type</th>
+						<th>Example</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						><td><code>start step size x len</code></td><td>Arithmetic series</td><td
+							><code>0step2x4</code></td
+						></tr
+					>
+					<tr
+						><td><code>start mul factor x len</code></td><td>Geometric series</td><td
+							><code>1mul2x4</code></td
+						></tr
+					>
+					<tr
+						><td><code>first lin last x len</code></td><td>Linear interpolation</td><td
+							><code>2lin7x8</code></td
+						></tr
+					>
+					<tr
+						><td><code>first geo last x len</code></td><td>Geometric interpolation</td><td
+							><code>2geo7x8</code></td
+						></tr
+					>
+					<tr
+						><td><code>utf8{'{'}word{'}'}</code></td><td>UTF-8 bytes, cycling</td><td
+							><code>utf8{'{'}coffee{'}'} % 14</code></td
+						></tr
+					>
+				</tbody>
+			</table>
+		</main>
+	</div>
 </div>
 
 <style>
 	.docs-page {
-		max-width: 800px;
+		max-width: 1100px;
 		margin: 0 auto;
 		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+
+	.toc-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: var(--space-4);
+		margin: var(--space-6) 0 var(--space-8);
+	}
+
+	.toc-card {
+		display: block;
+		padding: var(--space-4) var(--space-5);
+		background: var(--surface-1);
+		border: var(--border-width) solid var(--border);
+		border-radius: var(--radius-md);
+		text-decoration: none;
+		transition:
+			background var(--duration-fast) var(--ease-smooth),
+			border-color var(--duration-fast) var(--ease-smooth);
+	}
+
+	.toc-card:hover {
+		background: var(--surface-2);
+		border-color: var(--interactive);
+		color: inherit;
+	}
+
+	.toc-card h2 {
+		font-size: var(--text-base);
+		font-weight: var(--weight-semibold);
+		color: var(--text-primary);
+		margin: 0 0 var(--space-1) 0;
+	}
+
+	.toc-card p {
+		font-size: var(--text-sm);
+		color: var(--text-secondary);
+		margin: 0;
+		line-height: var(--leading-relaxed);
 	}
 </style>

--- a/src/routes/docs/buffers/+page.svelte
+++ b/src/routes/docs/buffers/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/buffers.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="buffers" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>

--- a/src/routes/docs/content-types/+page.svelte
+++ b/src/routes/docs/content-types/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/content-types.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="content-types" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>

--- a/src/routes/docs/decorators/+page.svelte
+++ b/src/routes/docs/decorators/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/decorators.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="decorators" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>

--- a/src/routes/docs/generators/+page.svelte
+++ b/src/routes/docs/generators/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/generators.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="generators" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>

--- a/src/routes/docs/get-started/+page.svelte
+++ b/src/routes/docs/get-started/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/get-started.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="get-started" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>

--- a/src/routes/docs/modifiers/+page.svelte
+++ b/src/routes/docs/modifiers/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/modifiers.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="modifiers" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>

--- a/src/routes/docs/params/+page.svelte
+++ b/src/routes/docs/params/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/params.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="params" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>

--- a/src/routes/docs/synthdefs/+page.svelte
+++ b/src/routes/docs/synthdefs/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import SiteHeader from '$lib/SiteHeader.svelte';
+	import DocsSidebar from '$lib/DocsSidebar.svelte';
+	import Content from '$docs/synthdefs.md';
+</script>
+
+<div class="docs-page">
+	<SiteHeader />
+	<div class="docs-layout">
+		<DocsSidebar active="synthdefs" />
+		<main class="prose">
+			<Content />
+		</main>
+	</div>
+</div>
+
+<style>
+	.docs-page {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.docs-layout {
+		display: flex;
+		gap: var(--space-8);
+		align-items: flex-start;
+	}
+</style>


### PR DESCRIPTION
## Summary

- Converts `/docs` landing page from a raw DSL-spec dump into a structured TOC with a card grid and quick-reference tables (sigils, content types, generators)
- Adds 8 doc sub-pages under `src/routes/docs/` — one per section — each backed by a new Markdown source file in `docs/`
- Adds `DocsSidebar` component with active-state highlighting shared across all doc pages
- New doc source files cover every built-in construct from the DSL spec and truth tables: generators (`rand`, `gau`, `exp`, `bro`, `step`, `mul`, `lin`, `geo`, `utf8{}`), modifiers (`'stut`, `'spread`, `'pick`, `'shuf`, `'arp`, `'rev`, `'mirror`, `'bounce`, `'maybe`, `'legato`, `'lock`, `'eager`, `'n`, `'at`, `'offset`), decorators (`@key`, `@scale`, `@root`, `@oct`, `@cent`, `@buf`), params (`"param`), content types (`note`, `mono`, `sample`, `slice`, `cloud`), SynthDefs, and Buffers

## Design decisions

- All doc pages import `.md` files via the existing `$docs` alias — no config changes needed
- `DocsSidebar` uses `resolve()` with explicit known routes to keep SvelteKit's typed route system happy (no template literal routes)
- Landing page keeps a compact quick-reference table alongside the section cards so experienced users can get answers without leaving the index

## Test plan

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm test` — 1048 tests pass (pre-existing Playwright browser not installed in dev container is unchanged)
- [x] `pnpm format` — all files formatted
- [x] Pre-existing ESLint `svelte.config.ts` failure is unchanged from main (pre-existing, not introduced here)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)