### PR TITLE
feat(UI): context-aware autocomplete — synthdefs, buffers, decorators, content types

### DIFF
--- a/docs/SynthDef-spec.md
+++ b/docs/SynthDef-spec.md
@@ -80,16 +80,17 @@ Metadata is embedded in the `.scd` file as a SuperCollider `Event` (dictionary l
 
 All fields are SC symbols or values as they appear in the `.scd` source.
 
-| Field             | SC type    | Required                | Description                                                       |
-| ----------------- | ---------- | ----------------------- | ----------------------------------------------------------------- |
-| `credit`          | String     | yes                     | Author name                                                       |
-| `type`            | Symbol     | yes                     | `\instrument` or `\fx`                                            |
-| `fx_role`         | Symbol     | yes (if `\fx`)          | `\insert` or `\master`                                            |
-| `description`     | String     | yes                     | Prose description of the sound or character                       |
-| `specs`           | Dictionary | yes                     | Keyed by control name Symbol; values are `ControlSpec` (see §3.2) |
-| `defaultBuffer`   | String     | yes (if declares `buf`) | Buffer name in the runtime registry loaded automatically at boot  |
-| `buffer_channels` | Integer    | yes (if declares `buf`) | Expected channel count of the associated buffer                   |
-| `url`             | String     | no                      | Link to documentation or demo                                     |
+| Field             | SC type      | Required                | Description                                                                         |
+| ----------------- | ------------ | ----------------------- | ----------------------------------------------------------------------------------- |
+| `credit`          | String       | yes                     | Author name                                                                         |
+| `type`            | Symbol       | yes                     | `\instrument` or `\fx`                                                              |
+| `fx_role`         | Symbol       | yes (if `\fx`)          | `\insert` or `\master`                                                              |
+| `contentTypes`    | Array\[Sym\] | no (see §3.3)           | Content-type keywords this SynthDef can back (e.g. `[\note, \mono]` or `[\sample]`) |
+| `description`     | String       | yes                     | Prose description of the sound or character                                         |
+| `specs`           | Dictionary   | yes                     | Keyed by control name Symbol; values are `ControlSpec` (see §3.2)                   |
+| `defaultBuffer`   | String       | yes (if declares `buf`) | Buffer name in the runtime registry loaded automatically at boot                    |
+| `buffer_channels` | Integer      | yes (if declares `buf`) | Expected channel count of the associated buffer                                     |
+| `url`             | String       | no                      | Link to documentation or demo                                                       |
 
 > `name` and `source` are not authored in the `.scd` file — they are injected by the compile script from the `SynthDef` name and filename respectively.
 
@@ -121,6 +122,30 @@ specs: Dictionary.newFrom([
 | _any number_    | `CurveWarp`       | Envelope-style curve; positive = convex, negative = concave (e.g. `4`, `-4`) |
 
 The compile script serialises each `ControlSpec` to a JSON object with the keys `min`, `max`, `default`, `curve`, `unit`. The `curve` field holds the SC symbol name (e.g. `"lin"`, `"exp"`, `"amp"`, `"db"`, `"sin"`, `"cos"`) or a number for `CurveWarp` instances. Named warps are kept as strings because each represents a distinct mapping function (`\exp` is a true exponential, `\amp` is x², `\db` maps through decibels) — there is no lossless reduction to a single number.
+
+### 3.3 `contentTypes` — DSL content-keyword eligibility
+
+`contentTypes` is an **optional** array of content-type symbols advertising which DSL keywords this SynthDef can serve as a default or selectable alternative for. It powers context-aware autocomplete in the editor: `note(\…)` suggests only defs whose `contentTypes` includes `\note`, and so on.
+
+| Content keyword | Meaning when listed                                                                |
+| --------------- | ---------------------------------------------------------------------------------- |
+| `\note`         | Polyphonic pitched instrument — new node per event                                 |
+| `\mono`         | Monophonic pitched instrument — single persistent node (usually pair with `\note`) |
+| `\sample`       | One-shot buffer player; event list contains `\symbol` buffer names                 |
+| `\slice`        | Beat-slice player; consumes `sliceIndex` + `numSlices`                             |
+| `\cloud`        | Granular cloud synth; persistent node                                              |
+
+**When to omit:** FX SynthDefs (`type: \fx`) are not driven by content keywords — they are invoked via `| fx(\…)`, `send_fx`, or `master_fx`. Omit `contentTypes` for FX defs. An empty array `[]` is semantically misleading (it would claim the def has zero valid content contexts), so omission is the idiomatic choice.
+
+**Example:**
+
+```sclang
+metadata: (
+    type: \instrument,
+    contentTypes: [\note, \mono],    // pitched — valid for both
+    ...
+)
+```
 
 ---
 

--- a/src/lib/lang/completions.test.ts
+++ b/src/lib/lang/completions.test.ts
@@ -21,7 +21,22 @@ const TEST_METADATA: SynthDefMetadata = {
 			amp: { default: 0.1, min: 0, max: 1, unit: 'amp', curve: 4 },
 			pan: { default: 0, min: -1, max: 1, unit: '', curve: 2 },
 			rel: { default: 0.2, min: 0.001, max: 4, unit: 'seconds', curve: 4 }
-		}
+		},
+		type: 'instrument'
+	},
+	fm: {
+		specs: {
+			amp: { default: 0.2, min: 0, max: 1, unit: 'amp', curve: 4 },
+			freq: { default: 440, min: 20, max: 20000, unit: 'Hz', curve: 4 },
+			pan: { default: 0, min: -1, max: 1, unit: '', curve: 2 }
+		},
+		type: 'instrument'
+	},
+	sliceplayer: {
+		specs: {
+			amp: { default: 0.5, min: 0, max: 1, unit: 'amp', curve: 4 }
+		},
+		type: 'fx'
 	}
 };
 
@@ -81,6 +96,20 @@ describe("getCompletions — trigger: '", () => {
 		const tokens = tokenize("note [0]'");
 		const items = getCompletions(tokens, endCursor("note [0]'"), "'");
 		expect(items.some((i: CompletionItem) => i.label === 'maybe(p)')).toBe(true);
+	});
+
+	it('modifier completions are in alphabetic order', () => {
+		const items = getCompletions([], 0, "'");
+		// Extract unique base labels (e.g. 'arp' from 'arp', 'arp(algorithm)', etc.)
+		const labels = items.map((i) => i.label);
+		// Check that sorted equals original for the first word of each label
+		const baseLabels = labels.map((l) => l.split('(')[0]);
+		const sorted = [...baseLabels].sort();
+		// Allow grouping by name (same base label adjacent)
+		// Just verify the labels start with ascending letters
+		const firstChars = baseLabels.filter((v, i, a) => a.indexOf(v) === i);
+		const sortedFirstChars = [...firstChars].sort();
+		expect(firstChars).toEqual(sortedFirstChars);
 	});
 });
 
@@ -163,28 +192,80 @@ describe('getCompletions — trigger: |', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. Trigger character: [
+// 3. Trigger character: [ — shows NOTHING (per design decision)
 // ---------------------------------------------------------------------------
 
-describe('getCompletions — trigger: [', () => {
-	it('returns sequence body completions for trigger char "["', () => {
+describe('getCompletions — trigger: [ (default: no suggestions)', () => {
+	it('returns empty array for trigger char "[" with no context', () => {
 		const items = getCompletions([], 0, '[');
-		expect(items.length).toBeGreaterThan(0);
+		expect(items).toHaveLength(0);
 	});
 
-	it('sequence body completions include a rand generator snippet', () => {
-		const items = getCompletions([], 0, '[');
-		expect(items.some((i: CompletionItem) => i.insertText.includes('rand'))).toBe(true);
+	it('returns empty array for trigger char "[" after note context (pitch patterns only)', () => {
+		const src = 'note lead [';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '[');
+		expect(items).toHaveLength(0);
 	});
 
-	it('sequence body completions include utf8{word} snippet', () => {
-		const items = getCompletions([], 0, '[');
-		expect(items.some((i: CompletionItem) => i.label.includes('utf8'))).toBe(true);
+	it('returns empty array when prev token is LBracket (explicit invocation)', () => {
+		const src = 'note [';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, endCursor(src), undefined);
+		expect(items).toHaveLength(0);
 	});
 });
 
 // ---------------------------------------------------------------------------
-// 3b. Top-level generator body completions (after generator name)
+// 3b. Trigger: [ in sample/slice/cloud context → show buffer names
+// ---------------------------------------------------------------------------
+
+describe('getCompletions — trigger: [ in sample/slice/cloud context', () => {
+	it('returns buffer names for trigger "[" after sample context', () => {
+		const src = 'sample drums [';
+		const tokens = tokenize(src);
+		const bufferNames = ['kick', 'snare', 'hat'];
+		const items = getCompletions(tokens, triggerCursor(src), '[', undefined, {}, bufferNames);
+		expect(items.length).toBe(3);
+		expect(items.every((i) => i.insertText.startsWith('\\'))).toBe(true);
+	});
+
+	it('returns buffer names for trigger "[" after slice context', () => {
+		const src = 'slice drums [';
+		const tokens = tokenize(src);
+		const bufferNames = ['amen', 'break'];
+		const items = getCompletions(tokens, triggerCursor(src), '[', undefined, {}, bufferNames);
+		expect(items.length).toBe(2);
+		expect(items.some((i) => i.label === '\\amen')).toBe(true);
+	});
+
+	it('returns buffer names for trigger "[" after cloud context', () => {
+		const src = 'cloud grain [';
+		const tokens = tokenize(src);
+		const bufferNames = ['myloop'];
+		const items = getCompletions(tokens, triggerCursor(src), '[', undefined, {}, bufferNames);
+		expect(items.length).toBe(1);
+		expect(items[0].label).toBe('\\myloop');
+	});
+
+	it('returns empty array for trigger "[" in sample context when no buffers registered', () => {
+		const src = 'sample drums [';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '[', undefined, {}, []);
+		expect(items).toHaveLength(0);
+	});
+
+	it('buffer name completion items have \\ prefix in label and insertText', () => {
+		const src = 'sample drums [';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '[', undefined, {}, ['kick']);
+		expect(items[0].label).toBe('\\kick');
+		expect(items[0].insertText).toBe('\\kick');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 3c. Top-level generator body completions (after generator name)
 // ---------------------------------------------------------------------------
 
 describe('getCompletions — top-level body (after generator name)', () => {
@@ -198,7 +279,60 @@ describe('getCompletions — top-level body (after generator name)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. Trigger character: ( — context-sensitive
+// 4. Trigger character: @ — decorator completions
+// ---------------------------------------------------------------------------
+
+describe('getCompletions — trigger: @', () => {
+	it('returns decorator completions for trigger char "@"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.length).toBeGreaterThan(0);
+	});
+
+	it('decorator completions include "key"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.some((i) => i.label === 'key')).toBe(true);
+	});
+
+	it('decorator completions include "scale"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.some((i) => i.label === 'scale')).toBe(true);
+	});
+
+	it('decorator completions include "root"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.some((i) => i.label === 'root')).toBe(true);
+	});
+
+	it('decorator completions include "octave"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.some((i) => i.label === 'octave')).toBe(true);
+	});
+
+	it('decorator completions include "cent"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.some((i) => i.label === 'cent')).toBe(true);
+	});
+
+	it('decorator completions include "buf"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.some((i) => i.label === 'buf')).toBe(true);
+	});
+
+	it('decorator completions do NOT include "set"', () => {
+		const items = getCompletions([], 0, '@');
+		expect(items.some((i) => i.label === 'set')).toBe(false);
+	});
+
+	it('decorator completions have snippet insertText with argument placeholder', () => {
+		const items = getCompletions([], 0, '@');
+		const keyItem = items.find((i) => i.label === 'key');
+		expect(keyItem?.isSnippet).toBe(true);
+		expect(keyItem?.insertText).toContain('${');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 5. Trigger character: ( — context-sensitive
 // ---------------------------------------------------------------------------
 
 describe('getCompletions — trigger: ( after Set', () => {
@@ -232,31 +366,112 @@ describe('getCompletions — trigger: ( after Set', () => {
 	});
 });
 
-describe('getCompletions — trigger: ( after Note', () => {
-	it('returns FX name completions after "note("', () => {
-		// Cursor is AT the '(' — lastTokenBefore sees 'Note'
+describe('getCompletions — trigger: ( after Note/Mono — instrument synthdefs', () => {
+	it('returns instrument synthdef completions after "note("', () => {
 		const src = 'note(';
 		const tokens = tokenize(src);
-		const items = getCompletions(tokens, triggerCursor(src), '(');
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
 		expect(items.length).toBeGreaterThan(0);
 	});
 
-	it('FX name completions include "lpf"', () => {
+	it('instrument synthdef completions include "kick" (type=instrument)', () => {
+		const src = 'note(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		expect(items.some((i) => i.label === 'kick')).toBe(true);
+	});
+
+	it('instrument synthdef completions include "fm" (type=instrument)', () => {
+		const src = 'note(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		expect(items.some((i) => i.label === 'fm')).toBe(true);
+	});
+
+	it('instrument synthdef completions do NOT include fx-type synthdefs', () => {
+		const src = 'note(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		// sliceplayer has type=fx in TEST_METADATA — should not appear
+		expect(items.some((i) => i.label === 'sliceplayer')).toBe(false);
+	});
+
+	it('instrument synthdef completions use \\symbol insertText format', () => {
+		const src = 'note(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		const kick = items.find((i) => i.label === 'kick');
+		expect(kick?.insertText).toBe('\\kick');
+	});
+
+	it('returns same instrument synthdefs for "mono("', () => {
+		const src = 'mono(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		expect(items.some((i) => i.label === 'kick')).toBe(true);
+		expect(items.some((i) => i.label === 'fm')).toBe(true);
+	});
+
+	it('returns empty array for note( when metadata is empty', () => {
 		const src = 'note(';
 		const tokens = tokenize(src);
 		const items = getCompletions(tokens, triggerCursor(src), '(');
-		expect(items.some((i: CompletionItem) => i.label === 'lpf')).toBe(true);
+		expect(items).toHaveLength(0);
+	});
+});
+
+describe('getCompletions — trigger: ( after Sample/Slice/Cloud', () => {
+	it('returns empty array after "sample(" (no instrument synthdefs for sample)', () => {
+		const src = 'sample(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		// sample only uses samplePlayer which is not in instrument metadata
+		expect(items).toHaveLength(0);
+	});
+
+	it('returns empty array after "slice("', () => {
+		const src = 'slice(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		expect(items).toHaveLength(0);
+	});
+
+	it('returns empty array after "cloud("', () => {
+		const src = 'cloud(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		expect(items).toHaveLength(0);
 	});
 
 	it('returns empty array for ( after an unrecognised preceding token', () => {
-		// Bare ( with no meaningful preceding token
 		const items = getCompletions([], 0, '(');
 		expect(items).toHaveLength(0);
 	});
 });
 
 // ---------------------------------------------------------------------------
-// 5. Explicit invocation (no trigger char) — inferred from preceding token
+// 6. Beginning-of-line: Ctrl+Space → content keywords
+// ---------------------------------------------------------------------------
+
+describe('getCompletions — beginning of line (Ctrl+Space)', () => {
+	it('returns content keywords for empty line (no trigger, no tokens)', () => {
+		const items = getCompletions([], 0, undefined);
+		expect(items.some((i) => i.label === 'note')).toBe(true);
+		expect(items.some((i) => i.label === 'mono')).toBe(true);
+		expect(items.some((i) => i.label === 'sample')).toBe(true);
+		expect(items.some((i) => i.label === 'slice')).toBe(true);
+		expect(items.some((i) => i.label === 'cloud')).toBe(true);
+	});
+
+	it('content keyword completions have kind=keyword', () => {
+		const items = getCompletions([], 0, undefined);
+		const note = items.find((i) => i.label === 'note');
+		expect(note?.kind).toBe('keyword');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 7. Explicit invocation (no trigger char) — inferred from preceding token
 // ---------------------------------------------------------------------------
 
 describe('getCompletions — explicit invocation (no triggerChar)', () => {
@@ -275,11 +490,11 @@ describe('getCompletions — explicit invocation (no triggerChar)', () => {
 		expect(items.some((i: CompletionItem) => i.label.includes('lpf'))).toBe(true);
 	});
 
-	it('returns sequence body completions when cursor is after LBracket', () => {
+	it('returns empty array when cursor is after LBracket (no placeholder suggestions)', () => {
 		const src = 'note [';
 		const tokens = tokenize(src);
 		const items = getCompletions(tokens, endCursor(src), undefined);
-		expect(items.length).toBeGreaterThan(0);
+		expect(items).toHaveLength(0);
 	});
 
 	it('returns empty array when cursor is not after a recognised trigger token', () => {
@@ -290,14 +505,14 @@ describe('getCompletions — explicit invocation (no triggerChar)', () => {
 		expect(items).toHaveLength(0);
 	});
 
-	it('returns empty array for an empty token list with no trigger', () => {
+	it('returns content keywords for empty token list (beginning of line)', () => {
 		const items = getCompletions([], 0, undefined);
-		expect(items).toHaveLength(0);
+		expect(items.some((i) => i.label === 'note')).toBe(true);
 	});
 });
 
 // ---------------------------------------------------------------------------
-// 6. CompletionItem shape
+// 8. CompletionItem shape
 // ---------------------------------------------------------------------------
 
 describe('CompletionItem shape', () => {

--- a/src/lib/lang/completions.test.ts
+++ b/src/lib/lang/completions.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { FluxLexer } from './lexer.js';
-import { getCompletions } from './completions.js';
+import { getCompletions, findActiveSynthDef } from './completions.js';
 import type { CompletionItem, SynthDefMetadata } from './completions.js';
 
 // Inline fixture matching static/compiled_synthdefs/metadata.json shape
@@ -22,7 +22,8 @@ const TEST_METADATA: SynthDefMetadata = {
 			pan: { default: 0, min: -1, max: 1, unit: '', curve: 2 },
 			rel: { default: 0.2, min: 0.001, max: 4, unit: 'seconds', curve: 4 }
 		},
-		type: 'instrument'
+		type: 'instrument',
+		contentTypes: ['note', 'mono']
 	},
 	fm: {
 		specs: {
@@ -30,13 +31,23 @@ const TEST_METADATA: SynthDefMetadata = {
 			freq: { default: 440, min: 20, max: 20000, unit: 'Hz', curve: 4 },
 			pan: { default: 0, min: -1, max: 1, unit: '', curve: 2 }
 		},
-		type: 'instrument'
+		type: 'instrument',
+		contentTypes: ['note', 'mono']
 	},
 	sliceplayer: {
 		specs: {
 			amp: { default: 0.5, min: 0, max: 1, unit: 'amp', curve: 4 }
 		},
 		type: 'fx'
+		// No contentTypes — fx defs are invoked via | fx(\…), not content keywords.
+	},
+	// A hypothetical sample-only instrument used to verify content-type filtering.
+	chopper: {
+		specs: {
+			amp: { default: 0.5, min: 0, max: 1, unit: 'amp', curve: 4 }
+		},
+		type: 'instrument',
+		contentTypes: ['sample']
 	}
 };
 
@@ -98,6 +109,16 @@ describe("getCompletions — trigger: '", () => {
 		expect(items.some((i: CompletionItem) => i.label === 'maybe(p)')).toBe(true);
 	});
 
+	it("modifier completions include 'numSlices(n)'", () => {
+		const tokens = tokenize("slice drums [0]'");
+		const items = getCompletions(tokens, endCursor("slice drums [0]'"), "'");
+		const numSlices = items.find((i: CompletionItem) => i.label === 'numSlices(n)');
+		expect(numSlices).toBeDefined();
+		expect(numSlices?.isSnippet).toBe(true);
+		expect(numSlices?.insertText).toContain('${');
+		expect(numSlices?.kind).toBe('snippet');
+	});
+
 	it('modifier completions are in alphabetic order', () => {
 		const items = getCompletions([], 0, "'");
 		// Extract unique base labels (e.g. 'arp' from 'arp', 'arp(algorithm)', etc.)
@@ -110,6 +131,48 @@ describe("getCompletions — trigger: '", () => {
 		const firstChars = baseLabels.filter((v, i, a) => a.indexOf(v) === i);
 		const sortedFirstChars = [...firstChars].sort();
 		expect(firstChars).toEqual(sortedFirstChars);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 1aa. findActiveSynthDef — token-walk helper
+// ---------------------------------------------------------------------------
+
+describe('findActiveSynthDef', () => {
+	it('returns the synthdef name from note(\\fm)', () => {
+		const src = 'note(\\fm) lead [0 1 2]"';
+		const tokens = tokenize(src);
+		expect(findActiveSynthDef(tokens, src.length)).toBe('fm');
+	});
+
+	it('returns the synthdef name from mono(\\kick)', () => {
+		const src = 'mono(\\kick) bass [0]"';
+		const tokens = tokenize(src);
+		expect(findActiveSynthDef(tokens, src.length)).toBe('kick');
+	});
+
+	it('returns the synthdef name from sample(\\oneshot)', () => {
+		const src = 'sample(\\oneshot) drums [\\kick]"';
+		const tokens = tokenize(src);
+		expect(findActiveSynthDef(tokens, src.length)).toBe('oneshot');
+	});
+
+	it('returns undefined when no content-type selection is present', () => {
+		const src = 'note lead [0 1 2]"';
+		const tokens = tokenize(src);
+		expect(findActiveSynthDef(tokens, src.length)).toBeUndefined();
+	});
+
+	it('returns undefined for an empty line', () => {
+		expect(findActiveSynthDef([], 0)).toBeUndefined();
+	});
+
+	it('picks the nearest selection when multiple could apply', () => {
+		// Unlikely real-world input, but verifies we walk right-to-left.
+		const src = 'note(\\fm) a | note(\\kick) b"';
+		const tokens = tokenize(src);
+		// The nearest walking backward from the end is kick.
+		expect(findActiveSynthDef(tokens, src.length)).toBe('kick');
 	});
 });
 
@@ -164,6 +227,44 @@ describe('getCompletions — trigger: "', () => {
 	it('returns empty array when no metadata provided', () => {
 		const items = getCompletions([], 0, '"');
 		expect(items).toHaveLength(0);
+	});
+
+	it('infers activeSynthDef from note(\\fm) — only fm params are offered', () => {
+		const src = 'note(\\fm) lead [0 1]"';
+		const tokens = tokenize(src);
+		// Caller passes activeSynthDef=undefined — inference must kick in.
+		const items = getCompletions(tokens, src.length, '"', undefined, TEST_METADATA);
+		// fm has freq; kick does not. If filtering works, freq appears.
+		expect(items.some((i) => i.label === 'freq')).toBe(true);
+		// kick has `rel`; fm does not. rel must NOT appear.
+		expect(items.some((i) => i.label === 'rel')).toBe(false);
+	});
+
+	it('infers activeSynthDef from mono(\\kick) — only kick params are offered', () => {
+		const src = 'mono(\\kick) bass [0]"';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, src.length, '"', undefined, TEST_METADATA);
+		expect(items.some((i) => i.label === 'rel')).toBe(true);
+		expect(items.some((i) => i.label === 'freq')).toBe(false);
+	});
+
+	it('explicit activeSynthDef argument wins over inferred value', () => {
+		// Line mentions note(\fm) but caller insists on kick.
+		const src = 'note(\\fm) lead [0]"';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, src.length, '"', 'kick', TEST_METADATA);
+		// kick's specs: amp, pan, rel. fm-only params like freq must not appear.
+		expect(items.some((i) => i.label === 'rel')).toBe(true);
+		expect(items.some((i) => i.label === 'freq')).toBe(false);
+	});
+
+	it('falls back to all synthdefs when line has no content-type selection', () => {
+		const src = 'note lead [0]"';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, src.length, '"', undefined, TEST_METADATA);
+		// Union mode — freq (from fm) and rel (from kick) both present.
+		expect(items.some((i) => i.label === 'freq')).toBe(true);
+		expect(items.some((i) => i.label === 'rel')).toBe(true);
 	});
 });
 
@@ -421,22 +522,25 @@ describe('getCompletions — trigger: ( after Note/Mono — instrument synthdefs
 });
 
 describe('getCompletions — trigger: ( after Sample/Slice/Cloud', () => {
-	it('returns empty array after "sample(" (no instrument synthdefs for sample)', () => {
+	it('returns synthdefs whose contentTypes includes "sample" after "sample("', () => {
 		const src = 'sample(';
 		const tokens = tokenize(src);
 		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
-		// sample only uses samplePlayer which is not in instrument metadata
-		expect(items).toHaveLength(0);
+		// TEST_METADATA fixture declares `chopper` with contentTypes:['sample'].
+		expect(items.some((i) => i.label === 'chopper')).toBe(true);
+		// note/mono-only defs must not appear.
+		expect(items.some((i) => i.label === 'kick')).toBe(false);
+		expect(items.some((i) => i.label === 'fm')).toBe(false);
 	});
 
-	it('returns empty array after "slice("', () => {
+	it('returns empty array after "slice(" (no slice-eligible synthdefs in fixture)', () => {
 		const src = 'slice(';
 		const tokens = tokenize(src);
 		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
 		expect(items).toHaveLength(0);
 	});
 
-	it('returns empty array after "cloud("', () => {
+	it('returns empty array after "cloud(" (no cloud-eligible synthdefs in fixture)', () => {
 		const src = 'cloud(';
 		const tokens = tokenize(src);
 		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
@@ -446,6 +550,49 @@ describe('getCompletions — trigger: ( after Sample/Slice/Cloud', () => {
 	it('returns empty array for ( after an unrecognised preceding token', () => {
 		const items = getCompletions([], 0, '(');
 		expect(items).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 5b. contentTypes filtering — note/mono only show eligible defs
+// ---------------------------------------------------------------------------
+
+describe('getCompletions — contentTypes filtering', () => {
+	it('note( does NOT include sample-only defs', () => {
+		const src = 'note(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		// `chopper` in the fixture has contentTypes:['sample'] — must not appear.
+		expect(items.some((i) => i.label === 'chopper')).toBe(false);
+	});
+
+	it('mono( does NOT include sample-only defs', () => {
+		const src = 'mono(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		expect(items.some((i) => i.label === 'chopper')).toBe(false);
+	});
+
+	it('note( excludes instrument defs without contentTypes', () => {
+		// A def with type:'instrument' but no contentTypes must not leak through.
+		const metaNoContentTypes: SynthDefMetadata = {
+			legacy: {
+				specs: { amp: { default: 0.1, min: 0, max: 1 } },
+				type: 'instrument'
+			}
+		};
+		const src = 'note(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, metaNoContentTypes);
+		expect(items).toHaveLength(0);
+	});
+
+	it('sample( excludes fx defs', () => {
+		const src = 'sample(';
+		const tokens = tokenize(src);
+		const items = getCompletions(tokens, triggerCursor(src), '(', undefined, TEST_METADATA);
+		// sliceplayer in fixture is type:'fx' with no contentTypes.
+		expect(items.some((i) => i.label === 'sliceplayer')).toBe(false);
 	});
 });
 

--- a/src/lib/lang/completions.ts
+++ b/src/lib/lang/completions.ts
@@ -149,6 +149,15 @@ const MODIFIER_COMPLETIONS: CompletionItem[] = [
 		kind: 'snippet'
 	},
 	{
+		label: 'numSlices(n)',
+		insertText: 'numSlices(${1:16})',
+		isSnippet: true,
+		detail: "'numSlices(n) — slice grid size (slice content type only)",
+		documentation:
+			"Tells the slice SynthDef how many slices the buffer is divided into. n must be a positive integer ≥ 1. Example: @buf(\\amen) slice drums [0 4 8 12]'numSlices(16)",
+		kind: 'snippet'
+	},
+	{
 		label: 'offset(ms)',
 		insertText: 'offset(${1:20})',
 		isSnippet: true,
@@ -409,10 +418,24 @@ export type SynthDefSpecEntry = {
 	unit?: string;
 	curve?: number | string;
 };
+
+/**
+ * Flux DSL content-type keywords. Advertised by `contentTypes` so the
+ * editor can suggest only SynthDefs that are valid for a given keyword —
+ * e.g. `note(\…)` only lists defs with `\note` in their `contentTypes`.
+ */
+export type FluxContentType = 'note' | 'mono' | 'sample' | 'slice' | 'cloud';
+
 export type SynthDefEntry = {
 	specs: Record<string, SynthDefSpecEntry>;
 	type?: string;
 	description?: string;
+	/**
+	 * Which DSL content keywords this SynthDef can back. FX synthdefs omit
+	 * this field (they are invoked via `| fx(\…)`, not content keywords).
+	 * See docs/SynthDef-spec.md §3.3.
+	 */
+	contentTypes?: FluxContentType[];
 };
 export type SynthDefMetadata = Record<string, SynthDefEntry>;
 
@@ -471,12 +494,26 @@ function getParamCompletions(
 }
 
 /**
- * Build completion items for instrument SynthDefs — offered after note( and mono(.
- * Only includes entries with type === 'instrument'.
+ * Build completion items for SynthDefs valid in a given content-type context.
+ *
+ * A SynthDef advertises the content keywords it supports via its
+ * `contentTypes` metadata field (see docs/SynthDef-spec.md §3.3). This
+ * function filters the registry to entries whose `contentTypes` includes
+ * the requested keyword.
+ *
+ * Entries with no `contentTypes` field are excluded — the mechanism is
+ * opt-in so misconfigured (or legacy FX) defs don't leak into instrument
+ * suggestions.
+ *
+ * @param synthdefMetadata - The loaded SynthDef metadata.
+ * @param contentType - 'note', 'mono', 'sample', 'slice', or 'cloud'.
  */
-function getInstrumentSynthDefCompletions(synthdefMetadata: SynthDefMetadata): CompletionItem[] {
+function getSynthDefCompletionsForContentType(
+	synthdefMetadata: SynthDefMetadata,
+	contentType: FluxContentType
+): CompletionItem[] {
 	return Object.entries(synthdefMetadata)
-		.filter(([, entry]) => entry.type === 'instrument')
+		.filter(([, entry]) => entry.contentTypes?.includes(contentType))
 		.map(([name, entry]) => ({
 			label: name,
 			insertText: `\\${name}`,
@@ -533,6 +570,52 @@ function findContentTypeKeyword(tokens: IToken[]): string | undefined {
 /** Content types that use buffer symbols in their sequence lists. */
 const BUFFER_CONTENT_TYPES = new Set(['Sample', 'Slice', 'Cloud']);
 
+/**
+ * Token-type names for content-keyword tokens that may introduce a SynthDef
+ * selection via `keyword(\name)`.
+ */
+const CONTENT_TYPE_TOKENS = new Set(['Note', 'Mono', 'Sample', 'Slice', 'Cloud']);
+
+/**
+ * Walk tokens backward from the cursor and return the nearest active SynthDef
+ * name introduced by `note(\NAME)`, `mono(\NAME)`, `sample(\NAME)`,
+ * `slice(\NAME)`, or `cloud(\NAME)`.
+ *
+ * Matching shape, reading right-to-left from the cursor's preceding token:
+ *
+ *   ... contentKeyword LParen Symbol(\name) RParen [...]
+ *                                                   ^ cursor anywhere after
+ *
+ * Returns the Symbol's image with the leading `\` stripped (e.g. `fm`). If
+ * no such selection exists on the line, returns undefined so the caller
+ * falls back to "all params from all synthdefs".
+ *
+ * Exported for testability.
+ */
+export function findActiveSynthDef(tokens: IToken[], cursorOffset: number): string | undefined {
+	// Build an index array of tokens that end before the cursor, in order.
+	// We scan right-to-left to find the nearest `keyword ( \name ) …` triple.
+	const eligible: IToken[] = [];
+	for (const t of tokens) {
+		const end = t.endOffset !== undefined ? t.endOffset : t.startOffset + t.image.length - 1;
+		if (end < cursorOffset) eligible.push(t);
+	}
+
+	// Walk right-to-left looking for: Symbol preceded by LParen preceded by a
+	// content keyword token.
+	for (let i = eligible.length - 1; i >= 2; i--) {
+		const tok = eligible[i];
+		if (tok.tokenType.name !== 'Symbol') continue;
+		const prev = eligible[i - 1];
+		const prevPrev = eligible[i - 2];
+		if (prev.tokenType.name !== 'LParen') continue;
+		if (!CONTENT_TYPE_TOKENS.has(prevPrev.tokenType.name)) continue;
+		// Strip the leading `\` from the symbol image
+		return tok.image.startsWith('\\') ? tok.image.slice(1) : tok.image;
+	}
+	return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -566,9 +649,13 @@ export function getCompletions(
 		return MODIFIER_COMPLETIONS;
 	}
 
-	// " trigger → SynthDef param names (prefix-filtered as user types)
+	// " trigger → SynthDef param names (prefix-filtered as user types).
+	// If the caller did not supply an explicit activeSynthDef, infer one by
+	// walking tokens backward for the nearest `note(\name)` / `mono(\name)` /
+	// etc. selection on the current line.
 	if (triggerChar === '"') {
-		return getParamCompletions(synthdefMetadata, activeSynthDef);
+		const effective = activeSynthDef ?? findActiveSynthDef(tokens, cursorOffset);
+		return getParamCompletions(synthdefMetadata, effective);
 	}
 
 	// | trigger → fx patterns
@@ -592,22 +679,32 @@ export function getCompletions(
 		return [];
 	}
 
-	// ( trigger → context-sensitive argument suggestions
+	// ( trigger → context-sensitive argument suggestions.
+	//
+	// Each content-type keyword filters the SynthDef registry by its
+	// `contentTypes` metadata: `note(` only shows defs eligible for `\note`,
+	// `sample(` only `\sample`, etc. Today only `fm` and `kick` advertise
+	// `[\note, \mono]` — sample/slice/cloud return [] in practice until a
+	// matching SynthDef ships, but the mechanism is in place.
 	if (triggerChar === '(') {
 		if (prevType === 'Set') return SET_PARAM_COMPLETIONS;
-		if (prevType === 'Note' || prevType === 'Mono') {
-			return getInstrumentSynthDefCompletions(synthdefMetadata);
-		}
-		// sample/slice/cloud: no instrument synthdefs apply; return empty
-		if (prevType === 'Sample' || prevType === 'Slice' || prevType === 'Cloud') {
-			return [];
-		}
+		if (prevType === 'Note') return getSynthDefCompletionsForContentType(synthdefMetadata, 'note');
+		if (prevType === 'Mono') return getSynthDefCompletionsForContentType(synthdefMetadata, 'mono');
+		if (prevType === 'Sample')
+			return getSynthDefCompletionsForContentType(synthdefMetadata, 'sample');
+		if (prevType === 'Slice')
+			return getSynthDefCompletionsForContentType(synthdefMetadata, 'slice');
+		if (prevType === 'Cloud')
+			return getSynthDefCompletionsForContentType(synthdefMetadata, 'cloud');
 		return [];
 	}
 
 	// Explicit invocation — infer from context
 	if (prevType === 'Tick') return MODIFIER_COMPLETIONS;
-	if (prevType === 'ParamSigil') return getParamCompletions(synthdefMetadata, activeSynthDef);
+	if (prevType === 'ParamSigil') {
+		const effective = activeSynthDef ?? findActiveSynthDef(tokens, cursorOffset);
+		return getParamCompletions(synthdefMetadata, effective);
+	}
 	if (prevType === 'Pipe') return PIPE_COMPLETIONS;
 	if (prevType === 'At') return DECORATOR_COMPLETIONS;
 

--- a/src/lib/lang/completions.ts
+++ b/src/lib/lang/completions.ts
@@ -8,11 +8,12 @@
  * CompletionItem format.
  *
  * Completion is largely static table lookups driven by trigger characters:
- *   '    → offer modifier names: lock, eager, stut, legato, at, n, tail, offset, …
+ *   '    → offer modifier names (alphabetic order)
  *   "    → offer SynthDef parameter names from metadata.json (prefix-filtered)
- *   [    → offer generators, scale degrees, literals
- *   (    → context-sensitive: synthdef names after note/mono/sample/slice/cloud/fx("…"), arg values after modifiers
+ *   [    → offer nothing by default; offer buffer names in sample/slice/cloud context
+ *   (    → context-sensitive: instrument synthdefs after note/mono, set-params after set
  *   |    → offer fx("…") patterns
+ *   @    → offer decorator names: key, scale, root, octave, cent, buf
  */
 
 import type { IToken } from 'chevrotain';
@@ -34,114 +35,8 @@ export interface CompletionItem {
 // Static completion tables
 // ---------------------------------------------------------------------------
 
+/** Modifier completions in alphabetic order by base name. */
 const MODIFIER_COMPLETIONS: CompletionItem[] = [
-	{
-		label: 'lock',
-		insertText: 'lock',
-		detail: "'lock — freeze value forever",
-		documentation:
-			'Generator is evaluated once at the first cycle and never redrawn. Inner lock overrides outer eager.',
-		kind: 'keyword'
-	},
-	{
-		label: 'eager',
-		insertText: 'eager',
-		detail: "'eager — redraw once per cycle (default)",
-		documentation: "Bare 'eager = 'eager(1).",
-		kind: 'keyword'
-	},
-	{
-		label: 'eager(n)',
-		insertText: 'eager(${1:4})',
-		isSnippet: true,
-		detail: "'eager(n) — redraw every n cycles",
-		documentation: 'n must be a positive integer ≥ 1.',
-		kind: 'snippet'
-	},
-	{
-		label: 'stut',
-		insertText: 'stut',
-		detail: "'stut — repeat each event twice",
-		documentation: "Default count = 2. Use 'stut(n) for a custom count.",
-		kind: 'keyword'
-	},
-	{
-		label: 'stut(n)',
-		insertText: 'stut(${1:2})',
-		isSnippet: true,
-		detail: "'stut(n) — repeat each event n times",
-		documentation: 'n must be a positive integer ≥ 1. Can be a generator.',
-		kind: 'snippet'
-	},
-	{
-		label: 'maybe',
-		insertText: 'maybe',
-		detail: "'maybe — pass each event with 50% probability",
-		documentation: "Bare 'maybe = 'maybe(0.5).",
-		kind: 'keyword'
-	},
-	{
-		label: 'maybe(p)',
-		insertText: 'maybe(${1:0.5})',
-		isSnippet: true,
-		detail: "'maybe(p) — pass each event with probability p",
-		documentation: 'p in [0.0, 1.0].',
-		kind: 'snippet'
-	},
-	{
-		label: 'legato(x)',
-		insertText: 'legato(${1:0.8})',
-		isSnippet: true,
-		detail: "'legato(x) — gate duration as fraction of event slot",
-		documentation: '1.0 = no gap. >1.0 = overlap (pad effect). Can be a generator.',
-		kind: 'snippet'
-	},
-	{
-		label: 'offset(ms)',
-		insertText: 'offset(${1:20})',
-		isSnippet: true,
-		detail: "'offset(ms) — timing offset in milliseconds",
-		documentation: 'Positive = late, negative = early.',
-		kind: 'snippet'
-	},
-	{
-		label: 'at(n)',
-		insertText: 'at(${1:1/4})',
-		isSnippet: true,
-		detail: "'at(n) — phase offset in cycles",
-		documentation: 'Offset from next cycle start. Fractions allowed. Applies to all content types.',
-		kind: 'snippet'
-	},
-	{
-		label: 'n',
-		insertText: 'n',
-		detail: "'n — play once",
-		documentation: "Bare 'n plays the pattern once.",
-		kind: 'keyword'
-	},
-	{
-		label: 'n(count)',
-		insertText: 'n(${1:4})',
-		isSnippet: true,
-		detail: "'n(count) — play n times",
-		documentation: 'count must be a positive integer ≥ 1.',
-		kind: 'snippet'
-	},
-	{
-		label: 'shuf',
-		insertText: 'shuf',
-		detail: "'shuf — shuffle list then traverse",
-		documentation: 'Re-shuffles at cycle boundary. Like Pshuf.',
-		kind: 'keyword'
-	},
-	{
-		label: 'pick',
-		insertText: 'pick',
-		detail: "'pick — random element each time (optionally weighted)",
-		documentation:
-			'Uniform random by default. Use `?n` on elements to assign non-negative weights; unweighted elements default to 1. Like Prand / Pwrand.',
-		kind: 'keyword'
-	},
 	{
 		label: 'arp',
 		insertText: 'arp',
@@ -169,20 +64,66 @@ const MODIFIER_COMPLETIONS: CompletionItem[] = [
 		kind: 'snippet'
 	},
 	{
-		label: 'tail(s)',
-		insertText: 'tail(${1:4})',
+		label: 'at(n)',
+		insertText: 'at(${1:1/4})',
 		isSnippet: true,
-		detail: "'tail(s) — release FX after s seconds of silence",
-		documentation: 'Applies to anonymous insert FX (fx(...)).',
+		detail: "'at(n) — phase offset in cycles",
+		documentation: 'Offset from next cycle start. Fractions allowed. Applies to all content types.',
 		kind: 'snippet'
 	},
 	{
-		label: 'rev',
-		insertText: 'rev',
-		detail: "'rev — reverse event array each cycle",
+		label: 'bounce',
+		insertText: 'bounce',
+		detail: "'bounce — palindrome without repeated endpoints",
 		documentation:
-			"Reverses the evaluated event array after traversal. [1 2 3 4]'rev → [4 3 2 1]. Single-element is a no-op.",
+			"Appends the reverse with both endpoints removed (ping-pong). [1 2 3]'bounce → [1 2 3 2]. Natural length = 2(N−1). Single-element is a no-op.",
 		kind: 'keyword'
+	},
+	{
+		label: 'eager',
+		insertText: 'eager',
+		detail: "'eager — redraw once per cycle (default)",
+		documentation: "Bare 'eager = 'eager(1).",
+		kind: 'keyword'
+	},
+	{
+		label: 'eager(n)',
+		insertText: 'eager(${1:4})',
+		isSnippet: true,
+		detail: "'eager(n) — redraw every n cycles",
+		documentation: 'n must be a positive integer ≥ 1.',
+		kind: 'snippet'
+	},
+	{
+		label: 'legato(x)',
+		insertText: 'legato(${1:0.8})',
+		isSnippet: true,
+		detail: "'legato(x) — gate duration as fraction of event slot",
+		documentation: '1.0 = no gap. >1.0 = overlap (pad effect). Can be a generator.',
+		kind: 'snippet'
+	},
+	{
+		label: 'lock',
+		insertText: 'lock',
+		detail: "'lock — freeze value forever",
+		documentation:
+			'Generator is evaluated once at the first cycle and never redrawn. Inner lock overrides outer eager.',
+		kind: 'keyword'
+	},
+	{
+		label: 'maybe',
+		insertText: 'maybe',
+		detail: "'maybe — pass each event with 50% probability",
+		documentation: "Bare 'maybe = 'maybe(0.5).",
+		kind: 'keyword'
+	},
+	{
+		label: 'maybe(p)',
+		insertText: 'maybe(${1:0.5})',
+		isSnippet: true,
+		detail: "'maybe(p) — pass each event with probability p",
+		documentation: 'p in [0.0, 1.0].',
+		kind: 'snippet'
 	},
 	{
 		label: 'mirror',
@@ -193,12 +134,73 @@ const MODIFIER_COMPLETIONS: CompletionItem[] = [
 		kind: 'keyword'
 	},
 	{
-		label: 'bounce',
-		insertText: 'bounce',
-		detail: "'bounce — palindrome without repeated endpoints",
-		documentation:
-			"Appends the reverse with both endpoints removed (ping-pong). [1 2 3]'bounce → [1 2 3 2]. Natural length = 2(N−1). Single-element is a no-op.",
+		label: 'n',
+		insertText: 'n',
+		detail: "'n — play once",
+		documentation: "Bare 'n plays the pattern once.",
 		kind: 'keyword'
+	},
+	{
+		label: 'n(count)',
+		insertText: 'n(${1:4})',
+		isSnippet: true,
+		detail: "'n(count) — play n times",
+		documentation: 'count must be a positive integer ≥ 1.',
+		kind: 'snippet'
+	},
+	{
+		label: 'offset(ms)',
+		insertText: 'offset(${1:20})',
+		isSnippet: true,
+		detail: "'offset(ms) — timing offset in milliseconds",
+		documentation: 'Positive = late, negative = early.',
+		kind: 'snippet'
+	},
+	{
+		label: 'pick',
+		insertText: 'pick',
+		detail: "'pick — random element each time (optionally weighted)",
+		documentation:
+			'Uniform random by default. Use `?n` on elements to assign non-negative weights; unweighted elements default to 1. Like Prand / Pwrand.',
+		kind: 'keyword'
+	},
+	{
+		label: 'rev',
+		insertText: 'rev',
+		detail: "'rev — reverse event array each cycle",
+		documentation:
+			"Reverses the evaluated event array after traversal. [1 2 3 4]'rev → [4 3 2 1]. Single-element is a no-op.",
+		kind: 'keyword'
+	},
+	{
+		label: 'shuf',
+		insertText: 'shuf',
+		detail: "'shuf — shuffle list then traverse",
+		documentation: 'Re-shuffles at cycle boundary. Like Pshuf.',
+		kind: 'keyword'
+	},
+	{
+		label: 'stut',
+		insertText: 'stut',
+		detail: "'stut — repeat each event twice",
+		documentation: "Default count = 2. Use 'stut(n) for a custom count.",
+		kind: 'keyword'
+	},
+	{
+		label: 'stut(n)',
+		insertText: 'stut(${1:2})',
+		isSnippet: true,
+		detail: "'stut(n) — repeat each event n times",
+		documentation: 'n must be a positive integer ≥ 1. Can be a generator.',
+		kind: 'snippet'
+	},
+	{
+		label: 'tail(s)',
+		insertText: 'tail(${1:4})',
+		isSnippet: true,
+		detail: "'tail(s) — release FX after s seconds of silence",
+		documentation: 'Applies to anonymous insert FX (fx(...)).',
+		kind: 'snippet'
 	}
 ];
 
@@ -215,60 +217,6 @@ const GENERATOR_BODY_COMPLETIONS: CompletionItem[] = [
 		detail: 'utf8{word} — UTF-8 bytes of a word as a melodic sequence',
 		documentation:
 			'Converts a bare identifier to its UTF-8 byte values and yields them cyclically. Each character becomes one event. Inspired by "coffee".ascii in SuperCollider.',
-		kind: 'snippet'
-	}
-];
-
-const SEQUENCE_BODY_COMPLETIONS: CompletionItem[] = [
-	{
-		label: '0 2 4 7',
-		insertText: '0 2 4 7]',
-		detail: 'Major chord degrees',
-		kind: 'value'
-	},
-	{
-		label: 'utf8{word}',
-		insertText: 'utf8{${1:coffee}}',
-		isSnippet: true,
-		detail: 'utf8{word} — UTF-8 bytes of a word as a cycling scalar',
-		documentation:
-			'Cycles through the UTF-8 byte values of the identifier, one byte per list slot per cycle.',
-		kind: 'snippet'
-	},
-	{
-		label: '0 2 4',
-		insertText: '0 2 4]',
-		detail: 'Triad',
-		kind: 'value'
-	},
-	{
-		label: '0 1 2 3',
-		insertText: '0 1 2 3]',
-		detail: 'Four steps',
-		kind: 'value'
-	},
-	{
-		label: '0 2 4 5 7 9 11',
-		insertText: '0 2 4 5 7 9 11]',
-		detail: 'Full major scale',
-		kind: 'value'
-	},
-	{
-		label: '0rand7',
-		insertText: '0rand7]',
-		detail: 'Random degree (integer)',
-		kind: 'snippet'
-	},
-	{
-		label: '0rand7 4rand6',
-		insertText: '0rand7 4rand6]',
-		detail: 'Two random degrees',
-		kind: 'snippet'
-	},
-	{
-		label: '[2 3] sublists',
-		insertText: '0 1 [2 3] 4]',
-		detail: 'Sublist for rhythmic subdivision',
 		kind: 'snippet'
 	}
 ];
@@ -301,20 +249,6 @@ const PIPE_COMPLETIONS: CompletionItem[] = [
 		detail: 'Insert delay',
 		kind: 'value'
 	}
-];
-
-/** Synthdef / FX names offered inside note("..."), mono("..."), fx("..."), etc. */
-const FX_NAME_COMPLETIONS: CompletionItem[] = [
-	{ label: 'lpf', insertText: 'lpf', detail: 'Low-pass filter', kind: 'value' },
-	{ label: 'hpf', insertText: 'hpf', detail: 'High-pass filter', kind: 'value' },
-	{ label: 'reverb', insertText: 'reverb', detail: 'Reverb', kind: 'value' },
-	{ label: 'delay', insertText: 'delay', detail: 'Delay', kind: 'value' },
-	{ label: 'distortion', insertText: 'distortion', detail: 'Distortion', kind: 'value' },
-	{ label: 'compressor', insertText: 'compressor', detail: 'Compressor', kind: 'value' },
-	{ label: 'limiter', insertText: 'limiter', detail: 'Limiter', kind: 'value' },
-	{ label: 'chorus', insertText: 'chorus', detail: 'Chorus', kind: 'value' },
-	{ label: 'flanger', insertText: 'flanger', detail: 'Flanger', kind: 'value' },
-	{ label: 'bitcrusher', insertText: 'bitcrusher', detail: 'Bitcrusher', kind: 'value' }
 ];
 
 /** Completions inside set(...). */
@@ -363,18 +297,123 @@ const SET_PARAM_COMPLETIONS: CompletionItem[] = [
 	}
 ];
 
+/**
+ * Decorator completions offered after '@'. Includes key, scale, root, octave, cent, buf.
+ * Does NOT include 'set' (that is a top-level keyword, not a decorator).
+ */
+const DECORATOR_COMPLETIONS: CompletionItem[] = [
+	{
+		label: 'key',
+		insertText: 'key(${1:g#} ${2:minor})',
+		isSnippet: true,
+		detail: '@key(root scale) — compound pitch context',
+		documentation:
+			'Sets root, scale, and optionally octave together. Most common way to establish key.\n\n```flux\n@key(g# minor)      // root = G#, scale = minor\n@key(c major)       // root = C, scale = major\n```',
+		kind: 'snippet'
+	},
+	{
+		label: 'scale',
+		insertText: 'scale(${1:minor})',
+		isSnippet: true,
+		detail: '@scale(name) — scale only',
+		documentation:
+			'Scale preset. Common scales: major, minor, dorian, phrygian, lydian, mixolydian, locrian, pentatonic_major, pentatonic_minor, chromatic, whole_tone.',
+		kind: 'snippet'
+	},
+	{
+		label: 'root',
+		insertText: 'root(${1:7})',
+		isSnippet: true,
+		detail: '@root(n) — root note (semitones from C)',
+		documentation:
+			'Root note as semitones from C (0–11). Accepts an integer or a stochastic generator.',
+		kind: 'snippet'
+	},
+	{
+		label: 'octave',
+		insertText: 'octave(${1:5})',
+		isSnippet: true,
+		detail: '@octave(n) — octave number',
+		documentation: 'Octave number (piano convention). Default: 5.',
+		kind: 'snippet'
+	},
+	{
+		label: 'cent',
+		insertText: 'cent(${1:10})',
+		isSnippet: true,
+		detail: '@cent(n) — fine pitch deviation in cents',
+		documentation: 'Deviates pitch by n cents (100 cents = 1 semitone). Accepts a generator.',
+		kind: 'snippet'
+	},
+	{
+		label: 'buf',
+		insertText: 'buf(\\${1:myloop})',
+		isSnippet: true,
+		detail: '@buf(\\name) — buffer selection for slice/cloud',
+		documentation:
+			"Specifies which buffer a slice or cloud pattern operates on. Accepts a symbol or sequence generator for per-cycle selection.\n\n```flux\n@buf(\\myloop) slice drums [0 4 8 12]\n@buf([\\loopA \\loopB]'pick) slice drums [0 4]\n```",
+		kind: 'snippet'
+	}
+];
+
+/** Content type keywords offered at the beginning of a line. */
+const CONTENT_TYPE_COMPLETIONS: CompletionItem[] = [
+	{
+		label: 'note',
+		insertText: 'note ',
+		detail: 'note name [...] — polyphonic pitched events',
+		documentation: 'Spawns a new synth instance for each event. Loops indefinitely by default.',
+		kind: 'keyword'
+	},
+	{
+		label: 'mono',
+		insertText: 'mono ',
+		detail: 'mono name [...] — monophonic pitched events',
+		documentation:
+			'Single persistent synth node; events send set messages instead of spawning new instances.',
+		kind: 'keyword'
+	},
+	{
+		label: 'sample',
+		insertText: 'sample ',
+		detail: 'sample name [\\sym ...] — buffer playback by name',
+		documentation: 'Each event is a \\symbol naming a loaded buffer.',
+		kind: 'keyword'
+	},
+	{
+		label: 'slice',
+		insertText: 'slice ',
+		detail: 'slice name [0 4 8 ...] — beat-sliced buffer playback',
+		documentation:
+			"Each event is an integer slice index. Use @buf(\\name) to select the buffer and 'numSlices(n) to set the grid.",
+		kind: 'keyword'
+	},
+	{
+		label: 'cloud',
+		insertText: 'cloud ',
+		detail: 'cloud name [] — granular synthesis',
+		documentation:
+			'Persistent granular synth node. The event list is typically empty; parameters controlled via "param notation.',
+		kind: 'keyword'
+	}
+];
+
 // ---------------------------------------------------------------------------
 // SynthDef metadata types (exported for use by callers / Monaco adapter)
 // ---------------------------------------------------------------------------
 
 export type SynthDefSpecEntry = {
-	default: number;
-	min: number;
-	max: number;
-	unit: string;
-	curve: number;
+	default?: number;
+	min?: number;
+	max?: number;
+	unit?: string;
+	curve?: number | string;
 };
-export type SynthDefEntry = { specs: Record<string, SynthDefSpecEntry> };
+export type SynthDefEntry = {
+	specs: Record<string, SynthDefSpecEntry>;
+	type?: string;
+	description?: string;
+};
 export type SynthDefMetadata = Record<string, SynthDefEntry>;
 
 // ---------------------------------------------------------------------------
@@ -416,14 +455,48 @@ function getParamCompletions(
 
 	return entries
 		.filter(([name]) => name.startsWith(prefix))
-		.map(([name, spec]) => ({
+		.map(([name, spec]) => {
+			const def = spec.default ?? 0;
+			const minVal = spec.min ?? 0;
+			const maxVal = spec.max ?? 1;
+			return {
+				label: name,
+				insertText: `${name}(\${1:${def}})`,
+				isSnippet: true,
+				detail: `"${name} — ${spec.unit ? `${spec.unit}, ` : ''}${minVal}–${maxVal}, default ${def}`,
+				documentation: `SynthDef parameter. Range: ${minVal}–${maxVal}. Default: ${def}.${spec.unit ? ` Unit: ${spec.unit}.` : ''}`,
+				kind: 'property' as CompletionItemKind
+			};
+		});
+}
+
+/**
+ * Build completion items for instrument SynthDefs — offered after note( and mono(.
+ * Only includes entries with type === 'instrument'.
+ */
+function getInstrumentSynthDefCompletions(synthdefMetadata: SynthDefMetadata): CompletionItem[] {
+	return Object.entries(synthdefMetadata)
+		.filter(([, entry]) => entry.type === 'instrument')
+		.map(([name, entry]) => ({
 			label: name,
-			insertText: `${name}(\${1:${spec.default}})`,
-			isSnippet: true,
-			detail: `"${name} — ${spec.unit ? `${spec.unit}, ` : ''}${spec.min}–${spec.max}, default ${spec.default}`,
-			documentation: `SynthDef parameter. Range: ${spec.min}–${spec.max}. Default: ${spec.default}.${spec.unit ? ` Unit: ${spec.unit}.` : ''}`,
-			kind: 'property' as CompletionItemKind
+			insertText: `\\${name}`,
+			detail: entry.description ? entry.description.slice(0, 80) : `SynthDef: ${name}`,
+			documentation: entry.description,
+			kind: 'value' as CompletionItemKind
 		}));
+}
+
+/**
+ * Build completion items for buffer names — offered after [ in sample/slice/cloud context.
+ * Each buffer name gets a \\ prefix in both label and insertText.
+ */
+function getBufferNameCompletions(bufferNames: string[]): CompletionItem[] {
+	return bufferNames.map((name) => ({
+		label: `\\${name}`,
+		insertText: `\\${name}`,
+		detail: 'buffer',
+		kind: 'value' as CompletionItemKind
+	}));
 }
 
 // ---------------------------------------------------------------------------
@@ -443,6 +516,23 @@ function lastTokenBefore(tokens: IToken[], cursorOffset: number): IToken | undef
 	return undefined;
 }
 
+/**
+ * Determine if the current line context is a sample/slice/cloud pattern.
+ * Returns the token type name of the content type keyword found, or undefined.
+ */
+function findContentTypeKeyword(tokens: IToken[]): string | undefined {
+	for (const t of tokens) {
+		const name = t.tokenType.name;
+		if (['Note', 'Mono', 'Sample', 'Slice', 'Cloud'].includes(name)) {
+			return name;
+		}
+	}
+	return undefined;
+}
+
+/** Content types that use buffer symbols in their sequence lists. */
+const BUFFER_CONTENT_TYPES = new Set(['Sample', 'Slice', 'Cloud']);
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -458,18 +548,20 @@ function lastTokenBefore(tokens: IToken[], cursorOffset: number): IToken | undef
  *   `"param` completions. If undefined, all known param names are offered.
  * @param synthdefMetadata - Runtime SynthDef metadata (loaded via fetch from
  *   /compiled_synthdefs/metadata.json). If not provided, param completions are empty.
+ * @param bufferNames - Current list of registered buffer names for \symbol completions.
  */
 export function getCompletions(
 	tokens: IToken[],
 	cursorOffset: number,
 	triggerChar?: string,
 	activeSynthDef?: string,
-	synthdefMetadata: SynthDefMetadata = {}
+	synthdefMetadata: SynthDefMetadata = {},
+	bufferNames: string[] = []
 ): CompletionItem[] {
 	const prev = lastTokenBefore(tokens, cursorOffset);
 	const prevType = prev?.tokenType.name;
 
-	// ' trigger → modifier names
+	// ' trigger → modifier names (alphabetic)
 	if (triggerChar === "'") {
 		return MODIFIER_COMPLETIONS;
 	}
@@ -484,19 +576,31 @@ export function getCompletions(
 		return PIPE_COMPLETIONS;
 	}
 
-	// [ trigger → sequence body suggestions
+	// @ trigger → decorator names (key, scale, root, octave, cent, buf)
+	if (triggerChar === '@') {
+		return DECORATOR_COMPLETIONS;
+	}
+
+	// [ trigger → context-sensitive
 	if (triggerChar === '[') {
-		return SEQUENCE_BODY_COMPLETIONS;
+		// In sample/slice/cloud context: show buffer names
+		const contentType = findContentTypeKeyword(tokens);
+		if (contentType && BUFFER_CONTENT_TYPES.has(contentType)) {
+			return getBufferNameCompletions(bufferNames);
+		}
+		// Otherwise: show nothing (per design: no placeholder suggestions)
+		return [];
 	}
 
 	// ( trigger → context-sensitive argument suggestions
 	if (triggerChar === '(') {
 		if (prevType === 'Set') return SET_PARAM_COMPLETIONS;
-		if (
-			prevType &&
-			['Note', 'Mono', 'Sample', 'Slice', 'Cloud', 'Fx', 'SendFx', 'MasterFx'].includes(prevType)
-		) {
-			return FX_NAME_COMPLETIONS;
+		if (prevType === 'Note' || prevType === 'Mono') {
+			return getInstrumentSynthDefCompletions(synthdefMetadata);
+		}
+		// sample/slice/cloud: no instrument synthdefs apply; return empty
+		if (prevType === 'Sample' || prevType === 'Slice' || prevType === 'Cloud') {
+			return [];
 		}
 		return [];
 	}
@@ -505,10 +609,25 @@ export function getCompletions(
 	if (prevType === 'Tick') return MODIFIER_COMPLETIONS;
 	if (prevType === 'ParamSigil') return getParamCompletions(synthdefMetadata, activeSynthDef);
 	if (prevType === 'Pipe') return PIPE_COMPLETIONS;
-	if (prevType === 'LBracket') return SEQUENCE_BODY_COMPLETIONS;
+	if (prevType === 'At') return DECORATOR_COMPLETIONS;
+
+	// LBracket: show buffer names in sample/slice/cloud context, nothing otherwise
+	if (prevType === 'LBracket') {
+		const contentType = findContentTypeKeyword(tokens);
+		if (contentType && BUFFER_CONTENT_TYPES.has(contentType)) {
+			return getBufferNameCompletions(bufferNames);
+		}
+		return [];
+	}
+
 	// After a generator name (Identifier token) — offer top-level body generators
 	// e.g. "note lead |cursor|" → suggest utf8{word} and other body forms
 	if (prevType === 'Identifier') return GENERATOR_BODY_COMPLETIONS;
+
+	// No tokens / empty line — beginning of line: suggest content type keywords
+	if (tokens.length === 0 || prev === undefined) {
+		return CONTENT_TYPE_COMPLETIONS;
+	}
 
 	return [];
 }

--- a/src/lib/lang/docs-index.test.ts
+++ b/src/lib/lang/docs-index.test.ts
@@ -1,0 +1,244 @@
+/**
+ * docs-index.ts unit tests.
+ *
+ * These cover the markdown parser and the public lookup API. The purpose is
+ * to lock in the contract the hover provider depends on: that every
+ * user-facing token in the DSL has a discoverable, deterministic key in
+ * the runtime doc index.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	lookupDocSection,
+	getDocMarkdown,
+	_extractKeysForTest,
+	_parseSectionsForTest,
+	_resetDocIndex
+} from './docs-index.js';
+
+// ---------------------------------------------------------------------------
+// extractKeys
+// ---------------------------------------------------------------------------
+
+describe('extractKeys', () => {
+	it("extracts the modifier name with leading sigil: 'stut(n)", () => {
+		expect(_extractKeysForTest("### `'stut(n)` — stutter")).toEqual(["'stut"]);
+	});
+
+	it("extracts bare modifier: 'lock", () => {
+		expect(_extractKeysForTest("### `'lock` — freeze forever")).toEqual(["'lock"]);
+	});
+
+	it('extracts decorator @key', () => {
+		expect(_extractKeysForTest('### `@key` — compound pitch context')).toEqual(['@key']);
+	});
+
+	it('extracts content type note', () => {
+		expect(_extractKeysForTest('## `note` — polyphonic pitched events')).toEqual(['note']);
+	});
+
+	it('extracts both `rand` and `~` when a heading has two code spans', () => {
+		expect(_extractKeysForTest('### White noise `rand` / `~`')).toEqual(['rand', '~']);
+	});
+
+	it('skips bracketed synthetic forms', () => {
+		expect(_extractKeysForTest('## Sequence lists `[...]`')).toEqual([]);
+	});
+
+	it('strips curly-brace argument suffix: utf8{word}', () => {
+		expect(_extractKeysForTest('## UTF-8 byte generator `utf8{word}`')).toEqual(['utf8']);
+	});
+
+	it("strips arp algorithm suffix: 'arp(\\\\up)", () => {
+		expect(_extractKeysForTest("### `'arp(\\up)` — ascending")).toEqual(["'arp"]);
+	});
+
+	it('returns empty array when heading has no code span', () => {
+		expect(_extractKeysForTest('## Timing')).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseSections
+// ---------------------------------------------------------------------------
+
+describe('parseSections', () => {
+	it('closes sections at same-or-shallower headings', () => {
+		const md = [
+			'# Top',
+			'',
+			'Top body.',
+			'',
+			'## A',
+			'',
+			'A body.',
+			'',
+			'## B',
+			'',
+			'B body.',
+			''
+		].join('\n');
+		const secs = _parseSectionsForTest('test', md);
+		const headings = secs.map((s) => s.heading);
+		expect(headings).toContain('## A');
+		expect(headings).toContain('## B');
+		const a = secs.find((s) => s.heading === '## A')!;
+		expect(a.body).toContain('A body');
+		expect(a.body).not.toContain('B body');
+	});
+
+	it('includes the first fenced code block in the body', () => {
+		const md = [
+			'### `foo`',
+			'',
+			'First paragraph.',
+			'',
+			'```flux',
+			'foo bar',
+			'```',
+			'',
+			'More prose.'
+		].join('\n');
+		const secs = _parseSectionsForTest('test', md);
+		const foo = secs.find((s) => s.heading.includes('foo'))!;
+		expect(foo.body).toContain('First paragraph');
+		expect(foo.body).toContain('```flux');
+		expect(foo.body).toContain('foo bar');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Real doc index — coverage across every docs file
+// ---------------------------------------------------------------------------
+
+describe('runtime doc index — lookupDocSection', () => {
+	it("finds modifiers.md section for 'stut", () => {
+		_resetDocIndex();
+		const s = lookupDocSection("'stut");
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('modifiers');
+		// The modifiers.md body for 'stut describes repetition — match loosely.
+		expect(s!.body.toLowerCase()).toMatch(/repeat|stut/);
+	});
+
+	it("finds modifiers.md section for 'lock", () => {
+		const s = lookupDocSection("'lock");
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('modifiers');
+	});
+
+	it("finds modifiers.md section for 'rev", () => {
+		const s = lookupDocSection("'rev");
+		expect(s).not.toBeNull();
+		expect(s!.body.toLowerCase()).toContain('revers');
+	});
+
+	it("finds modifiers.md section for 'numSlices", () => {
+		const s = lookupDocSection("'numSlices");
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('modifiers');
+	});
+
+	it('finds decorators.md section for @key', () => {
+		const s = lookupDocSection('@key');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('decorators');
+		expect(s!.body.toLowerCase()).toMatch(/root|scale/);
+	});
+
+	it('finds decorators.md section for @buf', () => {
+		const s = lookupDocSection('@buf');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('decorators');
+		expect(s!.body.toLowerCase()).toContain('slice');
+	});
+
+	it('finds generators.md section for rand', () => {
+		const s = lookupDocSection('rand');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('generators');
+	});
+
+	it('finds generators.md section for ~ (tilde shorthand)', () => {
+		const s = lookupDocSection('~');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('generators');
+	});
+
+	it('finds generators.md section for step', () => {
+		const s = lookupDocSection('step');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('generators');
+	});
+
+	it('finds generators.md section for utf8', () => {
+		const s = lookupDocSection('utf8');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('generators');
+		expect(s!.body.toLowerCase()).toContain('utf-8');
+	});
+
+	it('finds content-types.md section for note', () => {
+		// modifiers.md does not define `note` at a heading level, so this is
+		// served from content-types.md.
+		const s = lookupDocSection('note');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('content-types');
+	});
+
+	it('finds content-types.md section for sample', () => {
+		const s = lookupDocSection('sample');
+		expect(s).not.toBeNull();
+		// `sample` is documented in both content-types.md and buffers.md —
+		// either is acceptable as long as the lookup resolves.
+		expect(['content-types', 'buffers']).toContain(s!.source);
+	});
+
+	it('finds synthdefs.md section for fm', () => {
+		const s = lookupDocSection('fm');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('synthdefs');
+	});
+
+	it('finds synthdefs.md section for samplePlayer', () => {
+		const s = lookupDocSection('samplePlayer');
+		expect(s).not.toBeNull();
+		expect(s!.source).toBe('synthdefs');
+	});
+
+	it('finds params.md section for the top-level Params heading ? no', () => {
+		// Top-level "# Params" has no code-span key, so it's unindexed.
+		// Instead, params.md is surfaced via sub-headings like "## Syntax" —
+		// none of which have code spans either. This test documents the
+		// deliberate decision to treat params.md as context-only; the
+		// `"param` hover path uses getParamHover() not the doc index.
+		expect(lookupDocSection('Params')).toBeNull();
+	});
+
+	it('returns null for unknown keys', () => {
+		expect(lookupDocSection('definitelyNotAKey_xyz')).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getDocMarkdown — rendered output shape
+// ---------------------------------------------------------------------------
+
+describe('getDocMarkdown', () => {
+	it("renders a bold heading + body for 'stut", () => {
+		const md = getDocMarkdown("'stut");
+		expect(md).not.toBeNull();
+		expect(md!.startsWith('**')).toBe(true);
+		expect(md!.toLowerCase()).toContain('stutter');
+	});
+
+	it('rendered markdown contains no leading # characters', () => {
+		const md = getDocMarkdown('@scale')!;
+		// First line should not start with markdown hash — we strip those.
+		expect(md.split('\n')[0].startsWith('#')).toBe(false);
+	});
+
+	it('returns null for unknown keys', () => {
+		expect(getDocMarkdown('nopeNope')).toBeNull();
+	});
+});

--- a/src/lib/lang/docs-index.ts
+++ b/src/lib/lang/docs-index.ts
@@ -1,0 +1,252 @@
+/**
+ * Flux DSL — runtime documentation loader.
+ *
+ * Imports the reference markdown files at build time via Vite's `?raw` import
+ * suffix and indexes them by heading so the hover provider can serve
+ * documentation from a single source of truth (the docs themselves).
+ *
+ * Indexing rules:
+ *  - We consider any heading (`#` … `####`) that begins with a backtick
+ *    run, e.g. `` ### `'stut(n)` — stutter ``.
+ *  - The key is the token inside the first backtick pair, stripped of any
+ *    argument suffix — `'stut(n)` → `'stut`, `@key` → `@key`, `note` → `note`.
+ *  - The section body is the text between that heading and the next heading
+ *    at the same-or-shallower level.
+ *  - The body is trimmed to "first paragraph + first fenced code block" so
+ *    hovers stay compact.
+ *
+ * The hardcoded tables in `hover.ts` remain the source for token-type level
+ * docs (e.g. `Integer`, `LBracket`) that have no matching heading. When a
+ * doc-sourced entry is available we prefer it.
+ */
+// Vite `?raw` suffix delivers the file contents as a string at build time.
+import modifiersMd from '../../../docs/modifiers.md?raw';
+import decoratorsMd from '../../../docs/decorators.md?raw';
+import generatorsMd from '../../../docs/generators.md?raw';
+import paramsMd from '../../../docs/params.md?raw';
+import contentTypesMd from '../../../docs/content-types.md?raw';
+import synthdefsMd from '../../../docs/synthdefs.md?raw';
+import buffersMd from '../../../docs/buffers.md?raw';
+
+/**
+ * All loaded raw docs. Exposed as a tuple of (name, text) pairs for testing.
+ */
+export const DOC_SOURCES: Array<[string, string]> = [
+	['modifiers', modifiersMd],
+	['decorators', decoratorsMd],
+	['generators', generatorsMd],
+	['params', paramsMd],
+	['content-types', contentTypesMd],
+	['synthdefs', synthdefsMd],
+	['buffers', buffersMd]
+];
+
+export interface DocSection {
+	/** The source doc file (without extension). */
+	source: string;
+	/** The full heading line (e.g. "### `'stut(n)` — stutter"). */
+	heading: string;
+	/** Markdown body (already trimmed to first paragraph + first code block). */
+	body: string;
+}
+
+/**
+ * Build the lookup key for a heading.
+ *
+ * We look for the first `` `...` `` run in the heading text and strip any
+ * trailing call-argument parentheses. Examples:
+ *
+ *   "### `'stut(n)` — stutter"            → "'stut"
+ *   "### `'lock` — freeze forever"        → "'lock"
+ *   "### `@key` — compound pitch context" → "@key"
+ *   "## `note` — polyphonic …"            → "note"
+ *   "### Linear series `step`"            → "step"
+ *   "### White noise `rand` / `~`"        → "rand" (and "~" as a second key)
+ *
+ * Returns null when the heading has no code span.
+ */
+function extractKeys(heading: string): string[] {
+	// Match each `...` run in the heading.
+	const runs = Array.from(heading.matchAll(/`([^`]+)`/g)).map((m) => m[1]);
+	if (runs.length === 0) return [];
+
+	const keys: string[] = [];
+	for (const raw of runs) {
+		// Drop call/brace/bracket argument suffix:
+		//   "'stut(n)"    → "'stut"
+		//   "utf8{word}"  → "utf8"
+		//   "'arp(\\up)"  → "'arp"
+		const key = raw.replace(/[({\[].*[)}\]]$/, '').trim();
+		// Skip synthetic forms like `[...]`, `<...>` — not hover targets
+		if (/^[\[<(]/.test(key)) continue;
+		if (key.length === 0) continue;
+		keys.push(key);
+	}
+	// Deduplicate while preserving order
+	return [...new Set(keys)];
+}
+
+/**
+ * Heading-line pattern. Captures the marker (#'s) and the remainder.
+ */
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+
+/**
+ * Trim a section body to "first paragraph + first fenced code block".
+ * Keeps the first paragraph of prose followed by the first ```…``` block
+ * that appears close to it (up to 40 body lines scanned).
+ *
+ * The result is enough to answer "what does this token do?" without
+ * overwhelming the hover popup.
+ */
+function trimBody(body: string): string {
+	const lines = body.split('\n');
+	// Skip leading blank lines
+	let i = 0;
+	while (i < lines.length && lines[i].trim() === '') i++;
+
+	// Read first paragraph
+	const paragraph: string[] = [];
+	while (i < lines.length && lines[i].trim() !== '') {
+		paragraph.push(lines[i]);
+		i++;
+	}
+	// Skip blank lines
+	while (i < lines.length && lines[i].trim() === '') i++;
+
+	// Optionally read first fenced code block that appears within the next
+	// 40 lines of body content.
+	const code: string[] = [];
+	const lookahead = Math.min(lines.length, i + 40);
+	let j = i;
+	while (j < lookahead) {
+		if (lines[j].trim().startsWith('```')) {
+			code.push(lines[j]);
+			j++;
+			while (j < lines.length && !lines[j].trim().startsWith('```')) {
+				code.push(lines[j]);
+				j++;
+			}
+			if (j < lines.length) {
+				code.push(lines[j]); // closing fence
+			}
+			break;
+		}
+		j++;
+	}
+
+	const parts = [paragraph.join('\n').trim()];
+	if (code.length > 0) parts.push(code.join('\n'));
+	return parts.filter((s) => s.length > 0).join('\n\n');
+}
+
+/**
+ * Parse a single doc file into a list of { heading, body } sections.
+ * Each section's body is everything from immediately after the heading until
+ * the next heading at the same-or-shallower level.
+ */
+function parseSections(source: string, text: string): DocSection[] {
+	const lines = text.split('\n');
+	const sections: DocSection[] = [];
+
+	type Open = { level: number; heading: string; start: number };
+	const stack: Open[] = [];
+
+	const close = (upToLevel: number, endLine: number) => {
+		while (stack.length > 0 && stack[stack.length - 1].level >= upToLevel) {
+			const top = stack.pop()!;
+			const body = lines.slice(top.start, endLine).join('\n');
+			sections.push({ source, heading: top.heading, body: trimBody(body) });
+		}
+	};
+
+	for (let k = 0; k < lines.length; k++) {
+		const m = lines[k].match(HEADING_RE);
+		if (!m) continue;
+		const level = m[1].length;
+		close(level, k);
+		stack.push({ level, heading: lines[k], start: k + 1 });
+	}
+	close(0, lines.length);
+
+	return sections;
+}
+
+/**
+ * Build the master key → DocSection index.
+ *
+ * A key may map to multiple candidate sections if the same token is
+ * documented in more than one doc file (e.g. `'at` appears in both
+ * modifiers.md and content-types.md). The first registered wins — order is
+ * determined by DOC_SOURCES, so modifiers/generators/params take precedence
+ * over the more overview-flavoured content-types/synthdefs/buffers.
+ */
+function buildIndex(): Map<string, DocSection> {
+	const idx = new Map<string, DocSection>();
+	for (const [name, text] of DOC_SOURCES) {
+		const sections = parseSections(name, text);
+		for (const section of sections) {
+			const keys = extractKeys(section.heading);
+			for (const key of keys) {
+				if (!idx.has(key)) idx.set(key, section);
+			}
+		}
+	}
+	return idx;
+}
+
+let _index: Map<string, DocSection> | null = null;
+
+function getIndex(): Map<string, DocSection> {
+	if (_index === null) _index = buildIndex();
+	return _index;
+}
+
+/**
+ * Look up a doc section by key.
+ *
+ * @param key - Hover key. See extractKeys() for the canonical form. Callers
+ *   should include the sigil when applicable (`'stut`, `@buf`). Plain words
+ *   (`note`, `rand`, `utf8`) are also valid.
+ * @returns The matching DocSection or null if none is registered.
+ */
+export function lookupDocSection(key: string): DocSection | null {
+	return getIndex().get(key) ?? null;
+}
+
+/**
+ * Render a DocSection to a hover-ready markdown string. Combines a small
+ * leading header derived from the heading with the trimmed body.
+ */
+export function renderDocSection(section: DocSection): string {
+	// Strip leading '#'s and spaces from the heading to produce a bold summary.
+	const cleanHeading = section.heading.replace(/^#{1,6}\s+/, '').trim();
+	return `**${cleanHeading}**\n\n${section.body}`.trim();
+}
+
+/**
+ * Convenience: look up and render in one call.
+ */
+export function getDocMarkdown(key: string): string | null {
+	const section = lookupDocSection(key);
+	return section ? renderDocSection(section) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Testing hooks
+// ---------------------------------------------------------------------------
+
+/** Reset the memoised index. Only used by tests. */
+export function _resetDocIndex(): void {
+	_index = null;
+}
+
+/** Exported for tests — re-parse a specific doc string. */
+export function _parseSectionsForTest(source: string, text: string): DocSection[] {
+	return parseSections(source, text);
+}
+
+/** Exported for tests — extract keys from a heading line. */
+export function _extractKeysForTest(heading: string): string[] {
+	return extractKeys(heading);
+}

--- a/src/lib/lang/hover.test.ts
+++ b/src/lib/lang/hover.test.ts
@@ -344,7 +344,120 @@ describe('HoverResult shape', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 9. Shape modifier hover docs ('rev, 'mirror, 'bounce)
+// 9. Runtime-docs-sourced hover content
+//
+// These tests lock in the contract that hover tooltips prefer the
+// build-time-imported docs/*.md content over the hardcoded tables in
+// hover.ts. Each token below exercises a different doc file.
+// ---------------------------------------------------------------------------
+
+describe('getHover — runtime docs integration', () => {
+	it("hovers 'stut (modifiers.md) via runtime docs", () => {
+		const toks = tokens("note [0]'stut");
+		const stutTok = toks.find((t) => t.image === 'stut')!;
+		const result = getHover(stutTok, 'Tick') as HoverResult;
+		expect(result).not.toBeNull();
+		// The doc section heading "### `'stut(n)` — stutter" is rendered as
+		// **`'stut(n)` — stutter** at the top of the hover markdown.
+		expect(result.contents).toContain("'stut");
+		expect(result.contents.toLowerCase()).toMatch(/repeat|stutter/);
+	});
+
+	it("hovers 'numSlices (modifiers.md) via runtime docs", () => {
+		const toks = tokens("slice drums [0]'numSlices(16)");
+		const nsTok = toks.find((t) => t.image === 'numSlices')!;
+		const result = getHover(nsTok, 'Tick') as HoverResult;
+		expect(result).not.toBeNull();
+		expect(result.contents).toContain('numSlices');
+	});
+
+	it('hovers @key (decorators.md) via runtime docs', () => {
+		const toks = tokens('@key');
+		const keyTok = toks.find((t) => t.image === 'key')!;
+		const result = getHover(keyTok, 'At') as HoverResult;
+		expect(result).not.toBeNull();
+		// Doc body mentions root/scale composition.
+		expect(result.contents.toLowerCase()).toMatch(/root|scale/);
+	});
+
+	it('hovers @buf (decorators.md) via runtime docs', () => {
+		const toks = tokens('@buf');
+		const bufTok = toks.find((t) => t.image === 'buf')!;
+		const result = getHover(bufTok, 'At') as HoverResult;
+		expect(result).not.toBeNull();
+		expect(result.contents.toLowerCase()).toContain('slice');
+	});
+
+	it('hovers Rand token via generators.md runtime docs', () => {
+		const toks = tokens('0rand4');
+		const randTok = toks.find((t) => t.tokenType.name === 'Rand')!;
+		const result = getHover(randTok) as HoverResult;
+		expect(result).not.toBeNull();
+		// generators.md describes rand as Pwhite-like uniform integer.
+		expect(result.contents.toLowerCase()).toMatch(/uniform|random|pwhite/);
+	});
+
+	it('hovers Utf8Kw via generators.md runtime docs', () => {
+		const toks = tokens('utf8{coffee}');
+		const u = toks.find((t) => t.tokenType.name === 'Utf8Kw')!;
+		const result = getHover(u) as HoverResult;
+		expect(result).not.toBeNull();
+		expect(result.contents).toContain('utf8');
+	});
+
+	it('hovers note keyword via content-types.md runtime docs', () => {
+		const toks = tokens('note lead [0]');
+		const noteTok = toks.find((t) => t.tokenType.name === 'Note')!;
+		const result = getHover(noteTok) as HoverResult;
+		expect(result).not.toBeNull();
+		// content-types.md: "## `note` — polyphonic pitched events"
+		expect(result.contents.toLowerCase()).toMatch(/polyphonic|pitched/);
+	});
+
+	it('hovers mono keyword via content-types.md runtime docs', () => {
+		const toks = tokens('mono bass [0]');
+		const monoTok = toks.find((t) => t.tokenType.name === 'Mono')!;
+		const result = getHover(monoTok) as HoverResult;
+		expect(result).not.toBeNull();
+		expect(result.contents.toLowerCase()).toMatch(/monophonic|persistent/);
+	});
+
+	it('hovers sample keyword via runtime docs (content-types or buffers)', () => {
+		const toks = tokens('sample drums [0]');
+		const sampleTok = toks.find((t) => t.tokenType.name === 'Sample')!;
+		const result = getHover(sampleTok) as HoverResult;
+		expect(result).not.toBeNull();
+		expect(result.contents.toLowerCase()).toContain('buffer');
+	});
+
+	it('hovers slice keyword via runtime docs', () => {
+		const toks = tokens('slice drums [0]');
+		const sliceTok = toks.find((t) => t.tokenType.name === 'Slice')!;
+		const result = getHover(sliceTok) as HoverResult;
+		expect(result).not.toBeNull();
+		expect(result.contents.toLowerCase()).toMatch(/slice|buffer/);
+	});
+
+	it('hovers cloud keyword via content-types.md runtime docs', () => {
+		const toks = tokens('cloud grain []');
+		const cloudTok = toks.find((t) => t.tokenType.name === 'Cloud')!;
+		const result = getHover(cloudTok) as HoverResult;
+		expect(result).not.toBeNull();
+		expect(result.contents.toLowerCase()).toMatch(/granular|cloud/);
+	});
+
+	it('hovers set keyword via decorators.md runtime docs', () => {
+		const toks = tokens('set scale(minor)');
+		const setTok = toks.find((t) => t.tokenType.name === 'Set')!;
+		const result = getHover(setTok) as HoverResult;
+		expect(result).not.toBeNull();
+		// decorators.md: "## `set` — global session state"
+		expect(result.contents.toLowerCase()).toMatch(/global|session|set/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 10. Shape modifier hover docs ('rev, 'mirror, 'bounce)
 // ---------------------------------------------------------------------------
 
 describe("getHover — 'rev, 'mirror, 'bounce modifier docs", () => {

--- a/src/lib/lang/hover.test.ts
+++ b/src/lib/lang/hover.test.ts
@@ -158,6 +158,30 @@ describe('getHover — identifier after Tick (modifier context)', () => {
 		const result = getHover(shufTok!, 'Tick');
 		expect(result).not.toBeNull();
 	});
+
+	it("Tick token hover mentions 'rev' modifier in common modifiers list", () => {
+		// The Tick token itself should mention rev, mirror, bounce in its documentation
+		const toks = tokens("note [0]'");
+		const tickTok = toks.find((t) => t.tokenType.name === 'Tick');
+		expect(tickTok).toBeDefined();
+		const result = getHover(tickTok!);
+		expect(result).not.toBeNull();
+		expect(result!.contents).toContain('rev');
+	});
+
+	it("Tick token hover mentions 'mirror' modifier", () => {
+		const toks = tokens("note [0]'");
+		const tickTok = toks.find((t) => t.tokenType.name === 'Tick');
+		const result = getHover(tickTok!);
+		expect(result!.contents).toContain('mirror');
+	});
+
+	it("Tick token hover mentions 'bounce' modifier", () => {
+		const toks = tokens("note [0]'");
+		const tickTok = toks.find((t) => t.tokenType.name === 'Tick');
+		const result = getHover(tickTok!);
+		expect(result!.contents).toContain('bounce');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -198,6 +222,22 @@ describe('getHover — identifier after @ or set (decorator context)', () => {
 		const result = getHover(keyTok!, 'Set');
 		expect(result).not.toBeNull();
 		expect(result!.contents).toContain('key');
+	});
+
+	it('returns decorator docs for "buf" after @', () => {
+		const toks = tokens('@buf');
+		const bufTok = toks.find((t) => t.image === 'buf');
+		expect(bufTok).toBeDefined();
+		const result = getHover(bufTok!, 'At');
+		expect(result).not.toBeNull();
+		expect(result!.contents).toContain('buf');
+	});
+
+	it('buf hover content describes buffer selection for slice/cloud', () => {
+		const toks = tokens('@buf');
+		const bufTok = toks.find((t) => t.image === 'buf');
+		const result = getHover(bufTok!, 'At') as HoverResult;
+		expect(result.contents).toContain('slice');
 	});
 });
 

--- a/src/lib/lang/hover.ts
+++ b/src/lib/lang/hover.ts
@@ -7,11 +7,40 @@
 
 import type { IToken } from 'chevrotain';
 import type { SynthDefMetadata } from './completions.js';
+import { getDocMarkdown } from './docs-index.js';
 
 export interface HoverResult {
 	/** Markdown string to display in the hover popup. */
 	contents: string;
 }
+
+// ---------------------------------------------------------------------------
+// Runtime docs lookup helpers
+//
+// Any hover content we can source from docs/*.md at build time wins over the
+// in-file tables below. The tables remain the authoritative fallback for
+// token-types that have no matching heading (literals, punctuation, etc.).
+// ---------------------------------------------------------------------------
+
+/** Token type name → doc-index key. */
+const TOKEN_TYPE_DOC_KEY: Record<string, string> = {
+	Note: 'note',
+	Mono: 'mono',
+	Sample: 'sample',
+	Slice: 'slice',
+	Cloud: 'cloud',
+	Utf8Kw: 'utf8',
+	Rand: 'rand',
+	Gau: 'gau',
+	Exp: 'exp',
+	Bro: 'bro',
+	Step: 'step',
+	Mul: 'mul',
+	Lin: 'lin',
+	Geo: 'geo',
+	Tilde: '~',
+	Set: 'set'
+};
 
 // ---------------------------------------------------------------------------
 // Documentation tables
@@ -645,31 +674,49 @@ export function getHover(
 		return getParamHover(paramName, activeSynthDef, synthdefMetadata);
 	}
 
-	// Non-identifier tokens: direct lookup by type name
+	// Non-identifier tokens: runtime docs → hardcoded tables fallback.
 	if (typeName !== 'Identifier') {
+		const docKey = TOKEN_TYPE_DOC_KEY[typeName];
+		if (docKey) {
+			const md = getDocMarkdown(docKey);
+			if (md) return { contents: md };
+		}
 		const doc = TOKEN_TYPE_DOCS[typeName];
 		return doc ? { contents: doc } : null;
 	}
 
-	// Identifier — resolve by context first, then fall back to image-based lookup
+	// Identifier — resolve by context first, preferring runtime docs then
+	// falling back to the image-based tables.
 	const image = token.image;
 
 	if (prevTokenName === 'Tick') {
+		const md = getDocMarkdown(`'${image}`);
+		if (md) return { contents: md };
 		const doc = MODIFIER_DOCS[image];
 		if (doc) return { contents: doc };
 	}
 
 	if (prevTokenName === 'At' || prevTokenName === 'Set') {
+		const md = getDocMarkdown(`@${image}`);
+		if (md) return { contents: md };
 		const doc = DECORATOR_DOCS[image];
 		if (doc) return { contents: doc };
 	}
 
-	// Image-based fallbacks (works when the preceding token is out of hover range)
+	// Image-based fallbacks (works when the preceding token is out of hover range).
+	// Try runtime-docs for both modifier and decorator flavours of the bare
+	// identifier before touching the hardcoded tables.
+	const modMd = getDocMarkdown(`'${image}`);
+	if (modMd) return { contents: modMd };
+
 	const modDoc = MODIFIER_DOCS[image];
 	if (modDoc) return { contents: modDoc };
 
 	const scaleDoc = SCALE_DOCS[image];
 	if (scaleDoc) return { contents: scaleDoc };
+
+	const decMd = getDocMarkdown(`@${image}`);
+	if (decMd) return { contents: decMd };
 
 	const decDoc = DECORATOR_DOCS[image];
 	if (decDoc) return { contents: decDoc };

--- a/src/lib/lang/hover.ts
+++ b/src/lib/lang/hover.ts
@@ -560,7 +560,13 @@ function getParamHover(
 	activeSynthDef: string | undefined,
 	synthdefMetadata: SynthDefMetadata
 ): HoverResult | null {
-	type SpecEntry = { default: number; min: number; max: number; unit: string; curve: number };
+	type SpecEntry = {
+		default?: number;
+		min?: number;
+		max?: number;
+		unit?: string;
+		curve?: number | string;
+	};
 	let spec: SpecEntry | undefined;
 	let defName: string | undefined;
 
@@ -585,9 +591,9 @@ function getParamHover(
 		'',
 		`| Property | Value |`,
 		`| -------- | ----- |`,
-		`| Default  | ${spec.default} |`,
-		`| Min      | ${spec.min} |`,
-		`| Max      | ${spec.max} |`,
+		spec.default !== undefined ? `| Default  | ${spec.default} |` : null,
+		spec.min !== undefined ? `| Min      | ${spec.min} |` : null,
+		spec.max !== undefined ? `| Max      | ${spec.max} |` : null,
 		spec.unit ? `| Unit     | ${spec.unit} |` : null
 	]
 		.filter(Boolean)

--- a/src/lib/lang/hover.ts
+++ b/src/lib/lang/hover.ts
@@ -226,7 +226,7 @@ const TOKEN_TYPE_DOCS: Record<string, string> = {
 		'',
 		'Attaches a modifier to the immediately preceding token.',
 		'',
-		'Common modifiers: `lock`, `eager(n)`, `stut`, `maybe`, `legato`, `offset`, `at`, `n`, `shuf`, `pick`, `arp`'
+		'Common modifiers: `lock`, `eager(n)`, `stut`, `maybe`, `legato`, `offset`, `at`, `n`, `shuf`, `pick`, `arp`, `rev`, `mirror`, `bounce`'
 	].join('\n'),
 
 	At: [
@@ -541,7 +541,19 @@ const DECORATOR_DOCS: Record<string, string> = {
 	octave: '**`octave`** — octave number (piano convention). Default: 5.',
 	cent: '**`cent`** — pitch deviation in cents (100 per semitone step). Default: 0.',
 	key: '**`key(root scale [octave])`** — compound pitch context: sets root + scale + optional octave together.',
-	tempo: '**`tempo`** — global tempo in BPM.'
+	tempo: '**`tempo`** — global tempo in BPM.',
+	buf: [
+		'**`@buf(\\\\name)`** — buffer selection for `slice` and `cloud`.',
+		'',
+		'Specifies which buffer a `slice` or `cloud` pattern operates on. Accepts a `\\\\symbol` or any sequence generator for per-cycle buffer selection.',
+		'',
+		'```flux',
+		'@buf(\\\\myloop) slice drums [0 2 4 8]',
+		"@buf([\\\\loopA \\\\loopB]'pick) slice drums [0 4 8 12]",
+		'```',
+		'',
+		'`@buf` on `sample` is a semantic error — buffer selection in `sample` is per-event inside the list.'
+	].join('\n')
 };
 
 // ---------------------------------------------------------------------------

--- a/src/lib/monaco-adapter.ts
+++ b/src/lib/monaco-adapter.ts
@@ -23,7 +23,11 @@
 
 import type * as Monaco from 'monaco-editor';
 import { FluxLexer } from '$lib/lang/lexer.js';
-import { getCompletions, type CompletionItemKind } from '$lib/lang/completions.js';
+import {
+	getCompletions,
+	type CompletionItemKind,
+	type SynthDefMetadata
+} from '$lib/lang/completions.js';
 import { getHover } from '$lib/lang/hover.js';
 
 // ---------------------------------------------------------------------------
@@ -245,6 +249,26 @@ export function setBufferNamesGetter(fn: BufferNamesGetter): void {
 }
 
 // ---------------------------------------------------------------------------
+// SynthDef metadata integration
+//
+// Synthdef metadata is loaded at page boot from /compiled_synthdefs/metadata.json.
+// The page calls setSynthDefMetadata once after loading.
+// ---------------------------------------------------------------------------
+
+let _synthDefMetadata: SynthDefMetadata = {};
+
+/**
+ * Set the SynthDef metadata used for content-aware completions.
+ * Call this once after loading metadata.json on page load.
+ *
+ * @example
+ *   setSynthDefMetadata(data.synthdefs as SynthDefMetadata);
+ */
+export function setSynthDefMetadata(metadata: SynthDefMetadata): void {
+	_synthDefMetadata = metadata;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -373,7 +397,7 @@ export function registerFluxLanguage(monaco: typeof Monaco): void {
 	// ------------------------------------------------------------------
 
 	monaco.languages.registerCompletionItemProvider('flux', {
-		triggerCharacters: ["'", '[', '(', '|', '\\'],
+		triggerCharacters: ["'", '[', '(', '|', '\\', '@'],
 
 		provideCompletionItems(model, position, context) {
 			const lineContent = model.getLineContent(position.lineNumber);
@@ -420,7 +444,14 @@ export function registerFluxLanguage(monaco: typeof Monaco): void {
 			};
 
 			const { tokens } = FluxLexer.tokenize(lineContent);
-			const items = getCompletions(tokens, col, context.triggerCharacter);
+			const items = getCompletions(
+				tokens,
+				col,
+				context.triggerCharacter,
+				undefined, // activeSynthDef: TODO wire from editor state
+				_synthDefMetadata,
+				_getBufferNames()
+			);
 
 			return {
 				suggestions: items.map((item) => ({

--- a/src/lib/monaco-adapter.ts
+++ b/src/lib/monaco-adapter.ts
@@ -444,11 +444,16 @@ export function registerFluxLanguage(monaco: typeof Monaco): void {
 			};
 
 			const { tokens } = FluxLexer.tokenize(lineContent);
+			// activeSynthDef is inferred from the token stream inside
+			// getCompletions() via findActiveSynthDef() — we pass undefined
+			// so the default walk-backward heuristic runs. To force a
+			// specific def, pass its name here (none of the current editor
+			// surfaces need this yet).
 			const items = getCompletions(
 				tokens,
 				col,
 				context.triggerCharacter,
-				undefined, // activeSynthDef: TODO wire from editor state
+				undefined,
 				_synthDefMetadata,
 				_getBufferNames()
 			);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,7 +11,8 @@
 	import FxPanel from '$lib/FxPanel.svelte';
 	import SamplePanel from '$lib/SamplePanel.svelte';
 	import { bufferRegistry } from '$lib/bufferRegistry.svelte.js';
-	import { setBufferNamesGetter } from '$lib/monaco-adapter.js';
+	import { setBufferNamesGetter, setSynthDefMetadata } from '$lib/monaco-adapter.js';
+	import type { SynthDefMetadata } from '$lib/lang/completions.js';
 	import type { PageData } from './$types';
 	import type { ParamSpec } from './+page';
 
@@ -214,6 +215,9 @@
 	// Wire the buffer registry into Monaco \symbol completions.
 	// setBufferNamesGetter is idempotent — safe to call here at module eval time.
 	setBufferNamesGetter(() => bufferRegistry.entries.map((e) => e.name));
+
+	// Wire synthdef metadata into Monaco completions for content-aware synthdef suggestions.
+	setSynthDefMetadata(data.synthdefs as SynthDefMetadata);
 
 	/**
 	 * Called by SamplePanel after a file is decoded.

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -17,6 +17,8 @@ type SynthDefMeta = {
 	fx_role?: string;
 	url: string;
 	specs?: Record<string, ParamSpec>;
+	/** Which DSL content keywords this SynthDef can back. See docs/SynthDef-spec.md §3.3. */
+	contentTypes?: ('note' | 'mono' | 'sample' | 'slice' | 'cloud')[];
 };
 
 export const load: PageLoad = async ({ fetch }) => {

--- a/synthdefs/fm.scd
+++ b/synthdefs/fm.scd
@@ -71,6 +71,7 @@ x = SynthDef(\fm, {
 metadata: (
 	credit: "Anders Eskildsen",
 	type: \instrument,
+	contentTypes: [\note, \mono],
 	specs: Dictionary.newFrom([
 		\freq, ControlSpec(20, 20000, \exp, 0, 440, "Hz"),
 		\amp, ControlSpec(0, 1, \amp, 0, 0.2, "amp"),

--- a/synthdefs/kick.scd
+++ b/synthdefs/kick.scd
@@ -19,6 +19,7 @@ k = SynthDef(\kick, {
 metadata: (
 	credit: "Anders Eskildsen",
 	type: \instrument,
+	contentTypes: [\note, \mono],
 	specs: Dictionary.newFrom([
 		\pan, ControlSpec(-1, 1, 2, 0.0, 0, ""),
 		\amp, ControlSpec(0, 1, 4, 0, 0.1, "amp"),


### PR DESCRIPTION
## Summary

- Replaces all placeholder/random-integer suggestions with context-sensitive completions that only surface names valid at the cursor position
- `'` trigger: modifier completions in alphabetic order
- `@` trigger: decorator completions — `key`, `scale`, `root`, `octave`, `cent`, `buf` (not `set`)
- `(` after `note`/`mono`: instrument-type synthdefs from `metadata.json` (filtered by `type === 'instrument'`)
- `(` after `sample`/`slice`/`cloud`: empty (no matching synthdefs in current metadata)
- `[` trigger: empty by default (no placeholder suggestions); loaded buffer names with `\` prefix in `sample`/`slice`/`cloud` context
- Empty line / Ctrl+Space: content-type keywords (`note`, `mono`, `sample`, `slice`, `cloud`)
- Wires `setSynthDefMetadata` into `+page.svelte` so synthdef completions use real metadata at runtime
- Modifier list reordered alphabetically
- `SynthDefSpecEntry` fields made optional for type-safe compatibility with `ParamSpec`

## Test plan

- [x] All 1073 existing tests pass
- [x] 62 new/updated tests in `completions.test.ts` covering all trigger contexts
- [x] `pnpm check` — no type errors (pre-existing `data` reference warning only)
- [x] `pnpm format` — applied; pre-existing lint issue with `svelte.config.ts` unchanged

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)