### PR TITLE
Transport: reset cycle clock on stop→play for immediate dispatch

### DIFF
--- a/docs/DSL-spec.md
+++ b/docs/DSL-spec.md
@@ -1049,3 +1049,27 @@ All generators are evaluated eagerly at the cycle boundary — never lazily mid-
 This guarantee is what makes `'stut` and other count-modifying modifiers tractable: the scheduler receives a complete, fixed-length event array per cycle and can calculate durations, gate times, and subdivisions without needing to consult generators again during playback.
 
 Generators have no access to external runtime state (e.g. MIDI input, sensor values, another pattern's current position) at the moment of playback. Values are committed at cycle start. This is intentional: Flux is a live coding tool, not a DAW. If a value should change, the performer re-evaluates the expression, which takes effect at the next cycle boundary.
+
+---
+
+## Transport Semantics
+
+### Start from stopped
+
+When the user starts playback from a stopped state (Ctrl-Enter while nothing is playing), the cycle clock and cycle counter are **reset to 0** and dispatching begins immediately — at beat 0 of cycle 0. "Immediately" means within the scheduler's normal lookahead window, not at the literal instant of the keystroke.
+
+This is a **phase-defining** action. There is no prior metrical frame to preserve, so the clock starts fresh. The first sound should arrive within one lookahead window (~100 ms) after the keypress.
+
+### Edit while running
+
+When the user re-evaluates while playback is already running (Ctrl-Enter while a loop is active), the change is **quantised to the next cycle boundary**. The outgoing loop plays to the end of its current cycle; the new loop picks up from beat 0 of the next cycle. The cycle clock is not reset — it continues uninterrupted.
+
+This is a **phase-preserving** action, consistent with TidalCycles and Sonic Pi. Quantising to the cycle boundary keeps patterns metrically aligned during live coding.
+
+### Pause/resume (future)
+
+If a pause state is added in the future, **pause→resume must preserve clock phase** — it must not reset the cycle clock. Resuming from a paused position is a phase-preserving action: the clock continues from where it was frozen. Only a full stop→play transition is phase-defining.
+
+### Cycle counter
+
+The cycle counter (used by `'stretch`, `cycleOffset`, and similar constructs) resets to 0 on every stop→play transition. Continuing the counter across stop/play boundaries is not a behaviour any pattern relies on, and resetting matches user expectation: pressing play always starts from cycle 0.

--- a/src/lib/clock.test.ts
+++ b/src/lib/clock.test.ts
@@ -265,14 +265,12 @@ describe('clock.reset()', () => {
 		expect(clock.currentBeat).toBeCloseTo(1);
 	});
 
-	it('throws if context is not set', () => {
-		// Create a fresh module-like state by stopping (no context set scenario is
-		// tested by verifying start() also throws — same guard path).
-		// reset() must throw the same "Clock: call setContext" error as start().
-		// We simulate this by clearing the context via a new instance check:
-		// The real test: after reset, clock behaves as if freshly started.
-		// (setContext is always called in beforeEach so this test verifies reset works
-		// when the context IS set — the throw path mirrors start() which is already tested.)
+	it('sets startTime correctly when called before any start() (context already set)', () => {
+		// The throw-if-no-context path is tested indirectly via the shared guard in start(),
+		// which is already covered in the start/stop describe block. The module-level singleton
+		// makes it impossible to unset the context from a test without accessing private state.
+		// This test verifies that reset() works from a never-started state (startTime is null).
+		// beforeEach always calls setContext(), so _ctx is non-null here.
 		setTime(3.0);
 		clock.reset(); // should not throw — context was set in beforeEach
 		expect(clock.startTime).toBeCloseTo(3.0);

--- a/src/lib/clock.test.ts
+++ b/src/lib/clock.test.ts
@@ -234,7 +234,70 @@ describe('clock.beatToAudioTime', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. audioContext accessor
+// 6. clock.reset() — restarts the clock from beat 0 at the current AudioContext time
+// ---------------------------------------------------------------------------
+
+describe('clock.reset()', () => {
+	it('sets startTime to current AudioContext.currentTime', () => {
+		setTime(5.0);
+		clock.start(); // started at t=5
+		setTime(10.0); // time has advanced
+		clock.reset(); // reset at t=10
+		expect(clock.startTime).toBeCloseTo(10.0);
+	});
+
+	it('currentBeat is 0 immediately after reset', () => {
+		setTime(0);
+		clock.start();
+		setTime(2.4); // some beats have elapsed
+		clock.reset(); // reset at t=2.4
+		// After reset, startTime = 2.4, currentTime = 2.4, so currentBeat = 0
+		expect(clock.currentBeat).toBeCloseTo(0);
+	});
+
+	it('currentBeat advances from 0 after reset', () => {
+		setTime(0);
+		clock.start();
+		setTime(5.0); // elapsed 5 seconds
+		clock.reset();
+		// clock was reset at t=5; now advance to t=5.6 (0.6s = 1 beat at 100bpm)
+		setTime(5.6);
+		expect(clock.currentBeat).toBeCloseTo(1);
+	});
+
+	it('throws if context is not set', () => {
+		// Create a fresh module-like state by stopping (no context set scenario is
+		// tested by verifying start() also throws — same guard path).
+		// reset() must throw the same "Clock: call setContext" error as start().
+		// We simulate this by clearing the context via a new instance check:
+		// The real test: after reset, clock behaves as if freshly started.
+		// (setContext is always called in beforeEach so this test verifies reset works
+		// when the context IS set — the throw path mirrors start() which is already tested.)
+		setTime(3.0);
+		clock.reset(); // should not throw — context was set in beforeEach
+		expect(clock.startTime).toBeCloseTo(3.0);
+	});
+
+	it('is independent of prior start() calls — discards old startTime', () => {
+		setTime(1.0);
+		clock.start();
+		setTime(100.0);
+		clock.reset(); // discard old startTime=1.0, set new startTime=100.0
+		expect(clock.startTime).toBeCloseTo(100.0);
+		expect(clock.currentBeat).toBeCloseTo(0);
+	});
+
+	it('works even when clock was previously stopped (startTime was null)', () => {
+		clock.stop(); // startTime = null
+		setTime(7.0);
+		clock.reset(); // should set startTime to 7.0 even from stopped state
+		expect(clock.startTime).toBeCloseTo(7.0);
+		expect(clock.currentBeat).toBeCloseTo(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 7. audioContext accessor
 // ---------------------------------------------------------------------------
 
 describe('clock.audioContext', () => {

--- a/src/lib/clock.ts
+++ b/src/lib/clock.ts
@@ -41,6 +41,18 @@ export const clock = {
 		_startTime = _ctx.currentTime;
 	},
 
+	/**
+	 * Reset the clock to beat 0 at the current AudioContext time.
+	 * Use this for stop→play transitions so playback begins immediately
+	 * rather than waiting for the next cycle boundary on the old clock.
+	 * The cycle counter resets to 0 because generators always restart
+	 * their traversal when playback begins from stopped.
+	 */
+	reset(): void {
+		if (_ctx === null) throw new Error('Clock: call setContext() before reset()');
+		_startTime = _ctx.currentTime;
+	},
+
 	stop(): void {
 		_startTime = null;
 	},

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -362,6 +362,10 @@
 		clearOutgoing();
 		handle?.stop();
 		handle = null;
+		// Stop the clock so clock.startTime is null in the stopped state.
+		// This is safe: the scheduler is no longer running so beatToAudioTime
+		// will not be called. The clock is reset on the next play action.
+		clock.stop();
 	}
 
 	onDestroy(() => {
@@ -392,15 +396,26 @@
 		}
 		const inst = instResult;
 
-		const firstPlay = clock.startTime === null;
-		if (firstPlay) clock.start();
-
 		const CYCLE_BEATS = 4; // 1 DSL cycle = 4 real beats
-		// On first play currentBeat is 0, so ceil(0/4)*4 = 0 = "right now".
-		// Add CYCLE_BEATS so the first event lands one cycle ahead, giving the
-		// lookahead scheduler enough runway to deliver bundles before their NTP time.
-		const nextCycleBeat =
-			Math.ceil(clock.currentBeat / CYCLE_BEATS) * CYCLE_BEATS + (firstPlay ? CYCLE_BEATS : 0);
+
+		// Branch on playback state:
+		// - Stopped (handle === null): reset the cycle clock to 0 and begin at beat 0
+		//   immediately. This is a phase-defining action — the first sound arrives within
+		//   the scheduler's lookahead window (~100 ms), not several seconds later.
+		// - Running (handle !== null): quantise the change to the next cycle boundary.
+		//   This is a phase-preserving action that keeps patterns metrically aligned
+		//   during live coding (consistent with the Transport Semantics spec section).
+		const startingFromStopped = handle === null;
+		if (startingFromStopped) {
+			clock.reset();
+		} else if (clock.startTime === null) {
+			// Safety: clock was somehow stopped without handle being cleared — start fresh.
+			clock.start();
+		}
+
+		const nextCycleBeat = startingFromStopped
+			? 0
+			: Math.ceil(clock.currentBeat / CYCLE_BEATS) * CYCLE_BEATS;
 
 		// Let the current loop finish its cycle, then stop it.
 		// setStopBeat prevents the old loop from scheduling the event at


### PR DESCRIPTION
## Summary

- On stop→play (Ctrl-Enter from stopped state), the cycle clock is now reset to 0 and the scheduler starts dispatching at beat 0 immediately — within the lookahead window (~100 ms). Previously, the scheduler waited for the next cycle boundary on the old clock, causing up to several seconds of silence before any sound.
- On edit-while-running, existing behaviour is preserved: the change is quantised to the next cycle boundary, keeping patterns metrically aligned.
- `handleStop` now calls `clock.stop()` to leave the clock in a clean null-startTime state when stopped.

## Files changed

- **`docs/DSL-spec.md`** — new "Transport Semantics" section documenting stop→play (phase-defining), edit-while-running (phase-preserving), pause→resume (future), and cycle counter reset semantics
- **`src/lib/clock.ts`** — `clock.reset()` method: sets `_startTime` to current `AudioContext.currentTime` (beats restart from 0)
- **`src/lib/clock.test.ts`** — 6 new tests for `clock.reset()`
- **`src/routes/+page.svelte`** — `handleEvaluate` branches on `handle === null` (stopped) vs running; `handleStop` calls `clock.stop()`

## Design decisions

- The stopped/running branch key is `handle === null`, not `clock.startTime === null`. The handle is the source of truth for playback state — the clock's startTime can be non-null even after stopping (prior to this PR).
- `clock.reset()` is a thin wrapper over `clock.start()` semantics with an explicit name that conveys intent at the call site. It does the same thing (`_startTime = ctx.currentTime`) but is callable from any state (stopped or running) without re-checking the context guard.
- The `+ (firstPlay ? CYCLE_BEATS : 0)` lookahead padding that existed in the old code is removed. It was added to give the scheduler "runway" before the first event, but `LOOKAHEAD_SECONDS = 0.1s` is the actual mechanism for that — passing `startBeat = 0` means `beatToAudioTime(0) = ctx.currentTime`, which is within the horizon and dispatched immediately on the first tick.

Closes #62